### PR TITLE
Fix implied URL parsing

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -1102,7 +1102,7 @@ class Parser {
 				);
 				foreach ($xpaths as $xpath) {
 					$url = $this->xpath->query($xpath, $e);
-					if ($url->length === 1) {
+					if ($url !== false && $url->length === 1) {
 						$return['url'][] = $this->resolveUrl($url->item(0)->getAttribute('href'));
 						break;
 					}

--- a/tests/Mf2/ClassicMicroformatsTest.php
+++ b/tests/Mf2/ClassicMicroformatsTest.php
@@ -704,7 +704,7 @@ END;
 		$parser = new Parser($input);
 		$result = $parser->parse();
 
-		$this->assertCount(3, $result['items'][0]['properties']);
+		$this->assertCount(2, $result['items'][0]['properties']);
 		$this->assertArrayNotHasKey('street-address', $result['items'][0]['properties']);
 		$this->assertArrayNotHasKey('locality', $result['items'][0]['properties']);
 		$this->assertArrayNotHasKey('country-name', $result['items'][0]['properties']);

--- a/tests/Mf2/ParseImpliedTest.php
+++ b/tests/Mf2/ParseImpliedTest.php
@@ -331,5 +331,18 @@ class ParseImpliedTest extends PHPUnit_Framework_TestCase {
 		$this->assertArrayHasKey('content', $result['items'][0]['properties']);
 	}
 
+
+	/**
+	 * Don't imply u-url if there are other u-*
+	 * @see http://microformats.org/wiki/microformats2-parsing#parsing_for_implied_properties
+	 * @see https://github.com/microformats/php-mf2/issues/183
+	 */
+	public function testNoImpliedUrl() {
+		$input = '<div class="h-entry"> <h1 class="p-name"><a href="https://example.com/this-post">Title</a></h1> <div class="e-content"> <p> blah blah blah </p> </div> <a href="https://example.org/syndicate" class="u-syndication"></a> </div>';
+		$result = Mf2\parse($input);
+
+		$this->assertArrayNotHasKey('url', $result['items'][0]['properties']);
+	}
+
 }
 


### PR DESCRIPTION
Fixes #183.

This takes inspiration from how photo parsing is handled. Basically we convert the semi-CSS selectors used in the parsing specification to XPath selectors.

Adds `ParseImpliedTest::testNoImpliedUrl` based on the case in #183. This should probably be given a better name, but I am drawing blanks.

Fixes `ClassicMicroformatsTest::testMixedMf2andMf1Case3`. This test was assuming a `url` property, but it no longer gets it because it has a nested microformat. At least I think this is right… Is it?