### PR TITLE
Filter tests relying on live internet connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Pull requests very welcome, please try to maintain stylistic, structural and nam
 
 ### Testing
 
-There are currently two separate test suites: one, in `tests/Mf2`, is written in phpunit, containing many microformats parsing examples as well as internal parser tests and regression tests for specific issues over php-mf2’s history. Run it with `./vendor/bin/phpunit`.
+There are currently two separate test suites: one, in `tests/Mf2`, is written in phpunit, containing many microformats parsing examples as well as internal parser tests and regression tests for specific issues over php-mf2’s history. Run it with `./vendor/bin/phpunit`. If you do not have a live internet connection, you can exclude tests that depend on it: `./vendor/bin/phpunit --exclude-group internet`.
 
 The other, in `tests/test-suite`, is a custom test harness which hooks up php-mf2 to the cross-platform [microformats test suite](https://github.com/microformats/tests). To run these tests you must first install the tests with `./composer.phar install`. Each test consists of a HTML file and a corresponding JSON file, and the suite can be run with `php ./tests/test-suite/test-suite.php`.
 

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -253,7 +253,7 @@ EOT;
 	}
 
 	/**
-	 * @group network
+	 * @group internet
 	 */
 	public function testFetchMicroformats() {
 		$mf = Mf2\fetch('http://waterpigs.co.uk/');
@@ -367,6 +367,7 @@ EOT;
 
 	/**
 	 * @see https://github.com/indieweb/php-mf2/issues/84
+	 * @group internet
 	 */
 	public function testRelativeURLResolvedWithFinalURL() {
 		$mf = Mf2\fetch('http://aaron.pk/4Zn5');


### PR DESCRIPTION
Following [the convention set by Guzzle](https://guzzle3.readthedocs.io/testing/unit-testing.html#group-internet-annotation) by introducing a test group “internet”. Did this for selfish reasons, as depending on the day, my testing will just kinda hang on these. Now those tests can easily be skipped: `./vendor/bin/phpunit --exclude-group internet`.