### PR TITLE
Fix <img> handling in implied p-name

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -463,19 +463,21 @@ class Parser {
 		}
 	}
 
-		/**
-		 * The following two methods implements plain text parsing.
-		 * @see https://wiki.zegnat.net/media/textparsing.html
-		 **/
-	public function textContent(DOMElement $element)
+	/**
+	 * The following two methods implements plain text parsing.
+	 * @param DOMElement $element
+	 * @param bool $implied
+	 * @see https://wiki.zegnat.net/media/textparsing.html
+	 **/
+	public function textContent(DOMElement $element, $implied=false)
 	{
 				return preg_replace(
 						'/(^[\t\n\f\r ]+| +(?=\n)|(?<=\n) +| +(?= )|[\t\n\f\r ]+$)/',
 						'',
-						$this->elementToString($element)
+						$this->elementToString($element, $implied)
 				);
 	}
-	private function elementToString(DOMElement $input)
+	private function elementToString(DOMElement $input, $implied=false)
 	{
 			$output = '';
 			foreach ($input->childNodes as $child) {
@@ -488,7 +490,7 @@ class Parser {
 							} else if ($tagName === 'IMG') {
 									if ($child->hasAttribute('alt')) {
 											$output .= ' ' . trim($child->getAttribute('alt'), "\t\n\f\r ") . ' ';
-									} else if ($child->hasAttribute('src')) {
+									} else if (!$implied && $child->hasAttribute('src')) {
 											$output .= ' ' . $this->resolveUrl(trim($child->getAttribute('src'), "\t\n\f\r ")) . ' ';
 									}
 							} else if ($tagName === 'BR') {

--- a/tests/Mf2/ParseImpliedTest.php
+++ b/tests/Mf2/ParseImpliedTest.php
@@ -364,5 +364,16 @@ class ParseImpliedTest extends PHPUnit_Framework_TestCase {
 		$this->assertArrayNotHasKey('url', $result['items'][0]['properties']);
 	}
 
+	/**
+	 * Do not use img src in implied p-name
+	 * @see https://github.com/microformats/php-mf2/issues/180
+	 */
+	public function testNoImgSrcImpliedName() {
+		$input = '<p class="h-card">My Name <img src="http://xyz" /></p>';
+		$result = Mf2\parse($input);
+
+		$this->assertArrayHasKey('name', $result['items'][0]['properties']);
+		$this->assertEquals('My Name', $result['items'][0]['properties']['name'][0]);
+	}
 }
 


### PR DESCRIPTION
When we [updated](https://github.com/microformats/php-mf2/pull/168/files) from the innerText to textContent methods we lost the `$implied` parameter. I added that back so the textContent algorithm could account for exceptions like this. @Zegnat can you review and confirm if this is the best way to handle this?

Fixes #180