### PR TITLE
parse microformats classes from the property attribute

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -183,16 +183,26 @@ function nestedMfPropertyNamesFromClass($class) {
  * @return mixed See return value of mf2\Parser::mfNameFromClass()
  */
 function mfNamesFromElement(\DOMElement $e, $prefix = 'h-') {
-	$class = $e->getAttribute('class');
-	return mfNamesFromClass($class, $prefix);
+	$class = $e->getAttribute('property');
+	$names = mfNamesFromClass($class, $prefix);
+	if(!$names) {
+		$class = $e->getAttribute('class');
+		$names = mfNamesFromClass($class, $prefix);
+	}
+	return $names;
 }
 
 /**
  * Wraps nestedMfPropertyNamesFromClass to handle an element as input
  */
 function nestedMfPropertyNamesFromElement(\DOMElement $e) {
-	$class = $e->getAttribute('class');
-	return nestedMfPropertyNamesFromClass($class);
+	$class = $e->getAttribute('property');
+	$names = nestedMfPropertyNamesFromClass($class);
+	if(!$names) {
+		$class = $e->getAttribute('class');
+		$names = nestedMfPropertyNamesFromClass($class);
+	}
+	return $names;
 }
 
 /**

--- a/tests/Mf2/ParsePTest.php
+++ b/tests/Mf2/ParsePTest.php
@@ -140,4 +140,23 @@ EOT;
 		$this->assertEquals('mention.tech', $result['items'][0]['properties']['name'][0]);
 	}
 
+	public function testPropertyParsesFromPropertyAttribute() {
+		$input = '<div class="h-entry"><p property="p-name">Name</div>';
+		$result = Mf2\parse($input);
+		$this->assertEquals('Name', $result['items'][0]['properties']['name'][0]);
+	}
+
+	public function testPropertyUsesClassWhenPropertyHasNonMfValues() {
+		$input = '<div class="h-entry"><p property="foo" class="p-foo">Foo</div>';
+		$result = Mf2\parse($input);
+		$this->assertEquals('Foo', $result['items'][0]['properties']['foo'][0]);
+	}
+
+	public function testPropertyUsesPropertyWhenBothPresent() {
+		$input = '<div class="h-entry"><p property="p-foo" class="p-bar">Foo</div>';
+		$result = Mf2\parse($input);
+		$this->assertEquals('Foo', $result['items'][0]['properties']['foo'][0]);
+		$this->assertArrayNotHasKey('bar', $result['items'][0]['properties']);
+	}
 }
+


### PR DESCRIPTION
only uses the value in the property attribute if the value contains actual microformats classes, otherwise falls back to class still.

does not modify the behavior of the value-class pattern since that relies on a non-prefixed value