### PR TITLE
parse-mf2: read whole contents of STDIN

### DIFF
--- a/bin/parse-mf2
+++ b/bin/parse-mf2
@@ -28,7 +28,7 @@ if (!empty($argv[1])) {
 	$url = null;
 }
 
-$result = Mf2\parse(fgets(STDIN), $url);
+$result = Mf2\parse(file_get_contents("php://stdin"), $url);
 
 if (defined('JSON_PRETTY_PRINT')) {
 	echo json_encode($result, JSON_PRETTY_PRINT);


### PR DESCRIPTION
[`fgets(STDIN)` reads only one line](https://www.php.net/manual/en/function.fgets.php), but we want to pass a string containing the whole contents of the input to `Mf2\parse`.