### PR TITLE
Update Travis CI and fix failing test

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,7 @@ end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 charset = utf-8
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,21 @@
 dist: trusty
 language: php
 php:
-	- 5.4
-	- 5.5
-	- 5.6
-	- 7.0
-	- 7.1
-	- 7.2
-	- 7.3
-	- nightly
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - nightly
 env:
-	- COMPOSER_REQUIRE=""
-	- COMPOSER_REQUIRE="composer require masterminds/html5"
+  - COMPOSER_REQUIRE=""
+  - COMPOSER_REQUIRE="composer require masterminds/html5"
 matrix:
-	fast_finish: true
-	allow_failures:
-		- php: nightly
+  fast_finish: true
+  allow_failures:
+    - php: nightly
 install:
-	- $COMPOSER_REQUIRE
+  - $COMPOSER_REQUIRE
 before_script: composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,21 @@
+dist: trusty
 language: php
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-  - nightly
+	- 5.4
+	- 5.5
+	- 5.6
+	- 7.0
+	- 7.1
+	- 7.2
+	- 7.3
+	- nightly
 env:
-  - COMPOSER_REQUIRE=""
-  - COMPOSER_REQUIRE="composer require masterminds/html5"
+	- COMPOSER_REQUIRE=""
+	- COMPOSER_REQUIRE="composer require masterminds/html5"
 matrix:
-  fast_finish: true
-  allow_failures:
-    - php: nightly
+	fast_finish: true
+	allow_failures:
+		- php: nightly
 install:
-  - $COMPOSER_REQUIRE
+	- $COMPOSER_REQUIRE
 before_script: composer install

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -372,7 +372,7 @@ EOT;
 	public function testRelativeURLResolvedWithFinalURL() {
 		$mf = Mf2\fetch('http://aaron.pk/4Zn5');
 
-		$this->assertEquals('https://aaronparecki.com/2014/12/23/5/photo.jpeg', $mf['items'][0]['properties']['photo'][0]);
+		$this->assertEquals('https://aaronparecki.com/img/1240x0/2014/12/23/5/photo.jpeg', $mf['items'][0]['properties']['photo'][0]);
 	}
 
 	public function testScriptTagContentsRemovedFromTextValue() {


### PR DESCRIPTION
In 2019-05, default Travis build environment no longer supports PHP 5.4 and 5.5. Switched to Trusty build environment. https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

Fixed a now-failing test due to live, changed image URL.