### PR TITLE
Remove dependence on mbstring extension

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -160,8 +160,8 @@ function nestedMfPropertyNamesFromClass($class) {
 	foreach (explode(' ', $class) as $classname) {
 		foreach ($prefixes as $prefix) {
 			// Check if $classname is a valid property classname for $prefix.
-			if (mb_substr($classname, 0, mb_strlen($prefix)) == $prefix && $classname != $prefix) {
-				$propertyName = mb_substr($classname, mb_strlen($prefix));
+			if (substr($classname, 0, strlen($prefix)) == $prefix && $classname != $prefix) {
+				$propertyName = substr($classname, strlen($prefix));
 				$propertyNames[$propertyName][] = $prefix;
 			}
 		}

--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -93,7 +93,12 @@ function fetch($url, $convertClassic = true, &$curlInfo=null) {
  * @return string
  */
 function unicodeToHtmlEntities($input) {
-	return mb_convert_encoding($input, 'HTML-ENTITIES', mb_detect_encoding($input));
+	// FIXME: This function purportedly works around UTF-8 decoding problems 
+	// in PHP's DOMDocument class circa 2012. Is this still necessary?
+	if (extension_loaded("mbstring")) {
+		return mb_convert_encoding($input, 'HTML-ENTITIES', mb_detect_encoding($input));	
+	}
+	return $input;
 }
 
 /**

--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -111,10 +111,9 @@ function collapseWhitespace($str) {
 }
 
 function unicodeTrim($str) {
-	// this is cheating. TODO: find a better way if this causes any problems
-	$str = str_replace(mb_convert_encoding('&nbsp;', 'UTF-8', 'HTML-ENTITIES'), ' ', $str);
-	$str = preg_replace('/^\s+/', '', $str);
-	return preg_replace('/\s+$/', '', $str);
+	// the binary sequence C2A0 is a UTF-8 non-breaking space character
+	$str = preg_replace('/^(?:\s|\x{C2}\x{A0})+/', '', $str);
+	return preg_replace('/(?:\s|\x{C2}\x{A0})+$/', '', $str);
 }
 
 /**


### PR DESCRIPTION
This patch removes reliance on the mbstring extension in three places:

1. The `unicodeTrim` function used mbstring to generate a UTF-8 encoding of a U+00A0 NO-BREAK SPACE character. This has been replaced by a sequence of byte escapes instead. The trimming has also been corrected not to substitute no-break spaces in the middle of the string
2. The `nestedMfPropertyNamesFromClass` function used mbstring to remove a prefix from the start of a string. All prefixes to remove are ASCII, however, making the use of mbstring unnecessary. The calls to mbstring functions have simply been replaced with their standard PHP equivalents
3. The  `unicodeToHtmlEntities` function uses mbstring to work around decoding problems in the `DOMDocument` class, according to commit d1c70ad288894f4c7e49278c0dc5588cd876d3f8. The commit in question does not elaborate on what these decoding problems are, nor is this functionality tested in the test suite. It is unclear if these problems even exist in modern PHP versions. I have elected to make the conversion optional, using mbstring if available.