### PR TITLE
Add a Dockerfile for a PHP5.6 dev environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*.Dockerfile
+vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,19 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
 	    "phpcompatibility/php-compatibility": "^9.3"
     },
+    "scripts": {
+        "cs-check": "phpcs",
+        "tests": "XDEBUG_MODE=coverage ./vendor/bin/phpunit tests --coverage-text --whitelist Mf2",
+        "test-mf1": "./vendor/bin/phpunit --group microformats/tests/mf1",
+        "check-and-test": [
+            "@cs-check",
+            "@tests"
+        ],
+        "check-and-test-all": [
+            "@check-and-test",
+            "@test-mf1"
+        ]
+    },
     "autoload": {
         "files": ["Mf2/Parser.php"]
     },

--- a/php56.Dockerfile
+++ b/php56.Dockerfile
@@ -1,0 +1,17 @@
+FROM php:5.6-cli
+
+COPY --from=composer:2.2.12 /usr/bin/composer /usr/bin/composer
+
+RUN apt-get update && apt-get install -y \
+      zip \
+    && rm -rf /var/cache/apt/
+
+RUN pecl install xdebug-2.5.5 \
+    && docker-php-ext-enable xdebug
+
+WORKDIR /usr/share/php-mf2
+COPY . .
+
+RUN composer install --prefer-dist --no-cache --no-interaction
+
+CMD ["composer", "--no-interaction", "run", "check-and-test-all"]


### PR DESCRIPTION
I didn't have a development setup running PHP5.6 so I put one together in the
form of the php56.Dockerfile.

Build the dockerfile:
`docker build -f php56.Dockerfile -t php-mf2:5.6 .`

Run the container and launch bash:
`docker run -it --rm php-mf2:5.6 bash`

I mostly need this to run the test suite, so I added some scripts into
composer.json for phpcs and phpunit w/ code coverage. The container will run
the check-and-test-all script automatically if no other script is provided:
`docker run -it --rm php-mf2:5.6`