### PR TITLE
Switch to Yoast PHP Polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
        }
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
         "mf2/tests": "dev-master#e9e2b905821ba0a5b59dab1a8eaf40634ce9cd49",
         "squizlabs/php_codesniffer": "^3.6.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-	    "phpcompatibility/php-compatibility": "^9.3"
+	      "phpcompatibility/php-compatibility": "^9.3",
+        "yoast/phpunit-polyfills": "^1.0"
     },
     "autoload": {
         "files": ["Mf2/Parser.php"]

--- a/tests/Mf2/ClassicMicroformatsTest.php
+++ b/tests/Mf2/ClassicMicroformatsTest.php
@@ -8,7 +8,7 @@ namespace Mf2\Parser\Test;
 
 use Mf2\Parser;
 use Mf2;
-use PHPUnit_Framework_TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Classic Microformats Test
@@ -17,8 +17,8 @@ use PHPUnit_Framework_TestCase;
  *
  * Mainly based off BC tables on http://microformats.org/wiki/microformats2#v2_vocabularies
  */
-class ClassicMicroformatsTest extends PHPUnit_Framework_TestCase {
-	public function setUp() {
+class ClassicMicroformatsTest extends TestCase {
+	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
 

--- a/tests/Mf2/CombinedMicroformatsTest.php
+++ b/tests/Mf2/CombinedMicroformatsTest.php
@@ -5,6 +5,7 @@ namespace Mf2\Parser\Test;
 use Mf2\Parser;
 use Mf2;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
 
 /**
  * Combined Microformats Test
@@ -15,6 +16,8 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  * @todo implement
  */
 class CombinedMicroformatsTest extends TestCase {
+	use AssertIsType;
+
 	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
@@ -429,7 +432,7 @@ END;
 		// Repeat in non-JSON-mode: expect the raw PHP to be an array. Check that its serialization is not what we need for mf2 JSON.
 		$parser = new Parser($input, null, false);
 		$output = $parser->parse();
-		$this->assertInternalType('array', $output['items'][0]['properties']);
+		$this->assertIsArray($output['items'][0]['properties']);
 		$this->assertSame('[]', json_encode($output['items'][0]['properties']));
 	}
 

--- a/tests/Mf2/CombinedMicroformatsTest.php
+++ b/tests/Mf2/CombinedMicroformatsTest.php
@@ -4,7 +4,7 @@ namespace Mf2\Parser\Test;
 
 use Mf2\Parser;
 use Mf2;
-use PHPUnit_Framework_TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Combined Microformats Test
@@ -14,9 +14,8 @@ use PHPUnit_Framework_TestCase;
  *
  * @todo implement
  */
-class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
-
-	public function setUp() {
+class CombinedMicroformatsTest extends TestCase {
+	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
 

--- a/tests/Mf2/MicroformatsTestSuiteTest.php
+++ b/tests/Mf2/MicroformatsTestSuiteTest.php
@@ -2,6 +2,8 @@
 
 namespace Mf2\Parser\Test;
 
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
 final class TestSuiteParser extends \Mf2\Parser
 {
     /** Actually textContent from before the whitespace normalisation merge (e8da04f93d548d26287a8980eca4216639cbc61d) */
@@ -49,7 +51,7 @@ final class TestSuiteParser extends \Mf2\Parser
     }
 }
 
-class MicroformatsTestSuiteTest extends \PHPUnit_Framework_TestCase
+class MicroformatsTestSuiteTest extends TestCase
 {
     /**
      * @dataProvider mf1TestsProvider

--- a/tests/Mf2/MicroformatsWikiExamplesTest.php
+++ b/tests/Mf2/MicroformatsWikiExamplesTest.php
@@ -7,7 +7,7 @@
 namespace Mf2\Parser\Test;
 
 use Mf2\Parser;
-use PHPUnit_Framework_TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Microformats Wiki Examples
@@ -19,9 +19,8 @@ use PHPUnit_Framework_TestCase;
  *
  * @author Barnaby Walters waterpigs.co.uk <barnaby@waterpigs.co.uk>
  */
-class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
-
-	public function setUp() {
+class MicroformatsWikiExamplesTest extends TestCase {
+	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
 
@@ -179,7 +178,7 @@ class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
 	"type": ["h-card"],
 	"properties": {
 	  "photo": [
-	     {  
+	     {
 		"value": "https://webfwd.org/content/about-experts/300.mitchellbaker/mentor_mbaker.jpg",
 		"alt": "photo of Mitchell"
 	     }

--- a/tests/Mf2/ParseDTTest.php
+++ b/tests/Mf2/ParseDTTest.php
@@ -7,11 +7,10 @@
 namespace Mf2\Parser\Test;
 
 use Mf2\Parser;
-use PHPUnit_Framework_TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class ParseDTTest extends PHPUnit_Framework_TestCase {
-
-	public function setUp() {
+class ParseDTTest extends TestCase {
+	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
 

--- a/tests/Mf2/ParseHtmlIdTest.php
+++ b/tests/Mf2/ParseHtmlIdTest.php
@@ -7,13 +7,13 @@ namespace Mf2\Parser\Test;
 
 use Mf2;
 use Mf2\Parser;
-use PHPUnit_Framework_TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
- * 
+ *
  */
-class ParseHtmlIdTest extends PHPUnit_Framework_TestCase {
-	public function setUp() {
+class ParseHtmlIdTest extends TestCase {
+	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
 

--- a/tests/Mf2/ParseImpliedTest.php
+++ b/tests/Mf2/ParseImpliedTest.php
@@ -7,16 +7,15 @@ namespace Mf2\Parser\Test;
 
 use Mf2;
 use Mf2\Parser;
-use PHPUnit_Framework_TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * @todo some of these can be made into single tests with dataProviders
  */
-class ParseImpliedTest extends PHPUnit_Framework_TestCase {
-	public function setUp() {
+class ParseImpliedTest extends TestCase {
+	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
-
 
 	public function testParsesImpliedPNameFromNodeValue() {
 		$input = '<span class="h-card">The Name</span>';

--- a/tests/Mf2/ParseLanguageTest.php
+++ b/tests/Mf2/ParseLanguageTest.php
@@ -8,11 +8,10 @@ namespace Mf2\Parser\Test;
 
 use Mf2\Parser;
 use Mf2;
-use PHPUnit_Framework_TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class ParseLanguageTest extends PHPUnit_Framework_TestCase {
-
-	public function setUp() {
+class ParseLanguageTest extends TestCase {
+	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
 

--- a/tests/Mf2/ParsePTest.php
+++ b/tests/Mf2/ParsePTest.php
@@ -8,12 +8,11 @@ namespace Mf2\Parser\Test;
 
 use Mf2;
 use Mf2\Parser;
-use PHPUnit_Framework_TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 
-class ParsePTest extends PHPUnit_Framework_TestCase {
-
-	public function setUp() {
+class ParsePTest extends TestCase {
+	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
 

--- a/tests/Mf2/ParseUTest.php
+++ b/tests/Mf2/ParseUTest.php
@@ -7,10 +7,10 @@ namespace Mf2\Parser\Test;
 
 use Mf2;
 use Mf2\Parser;
-use PHPUnit_Framework_TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class ParseUTest extends PHPUnit_Framework_TestCase {
-	public function setUp() {
+class ParseUTest extends TestCase {
+	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
 

--- a/tests/Mf2/ParseValueClassTitleTest.php
+++ b/tests/Mf2/ParseValueClassTitleTest.php
@@ -8,11 +8,10 @@ namespace Mf2\Parser\Test;
 
 use Mf2;
 use Mf2\Parser;
-use PHPUnit_Framework_TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class ParseValueClassTitleTest extends PHPUnit_Framework_TestCase {
-
-	public function setUp() {
+class ParseValueClassTitleTest extends TestCase {
+	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
 

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -5,6 +5,8 @@ namespace Mf2\Parser\Test;
 use Mf2\Parser;
 use Mf2;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
 
 /**
  * Parser Test
@@ -15,6 +17,9 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  * Stuff for parsing E goes in here until there is enough of it to go elsewhere (like, never?)
  */
 class ParserTest extends TestCase {
+	use AssertIsType;
+	use AssertStringContains;
+
 	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
@@ -264,7 +269,7 @@ EOT;
 
 		$mf = Mf2\fetch('http://waterpigs.co.uk/photo.jpg', null, $curlInfo);
 		$this->assertNull($mf);
-		$this->assertContains('jpeg', $curlInfo['content_type']);
+		$this->assertStringContainsString('jpeg', $curlInfo['content_type']);
 	}
 
 	/**
@@ -392,8 +397,11 @@ EOT;
 		$output = $parser->parse();
 
 		$this->assertContains('h-entry', $output['items'][0]['type']);
-		$this->assertContains('Hello World', $output['items'][0]['properties']['content'][0]);
-		$this->assertNotContains('alert', $output['items'][0]['properties']['content'][0]);
+		$this->assertStringContainsString(
+			'Hello World',
+			$output['items'][0]['properties']['content'][0]
+		);
+		$this->assertStringNotContainsString('alert', $output['items'][0]['properties']['content'][0]);
 	}
 
 	public function testScriptElementContentsRemovedFromAllPlaintextValues() {
@@ -407,8 +415,8 @@ EOT;
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
-		$this->assertNotContains('not contained', $output['items'][0]['properties']['published'][0]);
-		$this->assertNotContains('not contained', $output['items'][0]['properties']['url'][0]);
+		$this->assertStringNotContainsString('not contained', $output['items'][0]['properties']['published'][0]);
+		$this->assertStringNotContainsString('not contained', $output['items'][0]['properties']['url'][0]);
 	}
 
 	public function testScriptTagContentsNotRemovedFromHTMLValue() {
@@ -430,13 +438,13 @@ EOT;
 		$output = $parser->parse();
 
 		$this->assertContains('h-entry', $output['items'][0]['type']);
-		$this->assertContains('Hello World', $output['items'][0]['properties']['content'][0]['value']);
-		$this->assertContains('<b>Hello World</b>', $output['items'][0]['properties']['content'][0]['html']);
+		$this->assertStringContainsString('Hello World', $output['items'][0]['properties']['content'][0]['value']);
+		$this->assertStringContainsString('<b>Hello World</b>', $output['items'][0]['properties']['content'][0]['html']);
 		# The script and style tags should be removed from plaintext results but left in HTML results.
-		$this->assertContains('alert', $output['items'][0]['properties']['content'][0]['html']);
-		$this->assertNotContains('alert', $output['items'][0]['properties']['content'][0]['value']);
-		$this->assertContains('visibility', $output['items'][0]['properties']['content'][0]['html']);
-		$this->assertNotContains('visibility', $output['items'][0]['properties']['content'][0]['value']);
+		$this->assertStringContainsString('alert', $output['items'][0]['properties']['content'][0]['html']);
+		$this->assertStringNotContainsString('alert', $output['items'][0]['properties']['content'][0]['value']);
+		$this->assertStringContainsString('visibility', $output['items'][0]['properties']['content'][0]['html']);
+		$this->assertStringNotContainsString('visibility', $output['items'][0]['properties']['content'][0]['value']);
 	}
 
 	public function testWhitespaceBetweenElements() {
@@ -841,8 +849,8 @@ END;
 EOD;
 
 		$output = Mf2\parse($input);
-		$this->assertInternalType('array', $output['items'][0]['properties']['comment'][0]['properties']);
-		$this->assertInternalType('array', $output['items'][0]['properties']['comment'][0]['children'][0]['properties']);
+		$this->assertIsArray($output['items'][0]['properties']['comment'][0]['properties']);
+		$this->assertIsArray($output['items'][0]['properties']['comment'][0]['children'][0]['properties']);
 		$this->assertEmpty($output['items'][0]['properties']['comment'][0]['properties']);
 		$this->assertEmpty($output['items'][0]['properties']['comment'][0]['children'][0]['properties']);
   }

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -4,7 +4,7 @@ namespace Mf2\Parser\Test;
 
 use Mf2\Parser;
 use Mf2;
-use PHPUnit_Framework_TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Parser Test
@@ -14,9 +14,8 @@ use PHPUnit_Framework_TestCase;
  *
  * Stuff for parsing E goes in here until there is enough of it to go elsewhere (like, never?)
  */
-class ParserTest extends PHPUnit_Framework_TestCase {
-
-	public function setUp() {
+class ParserTest extends TestCase {
+	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
 

--- a/tests/Mf2/PlainTextTest.php
+++ b/tests/Mf2/PlainTextTest.php
@@ -1,8 +1,9 @@
 <?php
 
 namespace Mf2\Parser\Test;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class PlainTextTest extends \PHPUnit_Framework_TestCase {
+class PlainTextTest extends TestCase {
     /**
      * @dataProvider aaronpkExpectations
      */

--- a/tests/Mf2/RelTest.php
+++ b/tests/Mf2/RelTest.php
@@ -7,13 +7,9 @@ namespace Mf2\Parser\Test;
 
 use Mf2;
 use Mf2\Parser;
-use PHPUnit_Framework_TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class RelTest extends PHPUnit_Framework_TestCase {
-  public function setUp() {
-    date_default_timezone_set('Europe/London');
-  }
-
+class RelTest extends TestCase {
   public function testRelValueOnLinkTag() {
     $input = '<link rel="webmention" href="http://example.com/webmention">';
     $parser = new Parser($input);

--- a/tests/Mf2/URLTest.php
+++ b/tests/Mf2/URLTest.php
@@ -7,11 +7,10 @@
 namespace Mf2\Parser\Test;
 
 use Mf2;
-use PHPUnit_Framework_TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class UrlTest extends PHPUnit_Framework_TestCase {
-
-	public function setUp() {
+class UrlTest extends TestCase {
+	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
 


### PR DESCRIPTION
See: https://github.com/microformats/php-mf2/pull/213 for history

Uses Yoast PHPUnit Polyfill, which I've personally used for 5.4 -> 8.1 compatibility previously.

Just need to see if the workflow passes.

This should unlock PHP8 / 8.1 compatibility.

It's another layer of indirection + a little bit of magic to not be coupled to the unstable API of PHPUnit.

> ⚠️ **Warning**
> This commit history depends on another to pass CI a separate issue #236 has been raised to fix that.
> https://github.com/Lewiscowles1986/php-mf2/pull/4 shows the combination passing CI