### PR TITLE
Feature/composer CI fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
 
     steps:
     - name: Set up PHP environment
-      if: steps.check_files.outputs.files_exists == 'true'
       uses: shivammathur/setup-php@v2
       with:
         php-version: '${{ matrix.php }}'
@@ -26,7 +25,6 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install Composer dependencies & cache dependencies
-      if: steps.check_files.outputs.files_exists == 'true'
       uses: "ramsey/composer-install@v2"
       with:
         composer-options: "--prefer-dist"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,28 +16,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: shivammathur/setup-php@2.11.0
+    - name: Set up PHP environment
+      if: steps.check_files.outputs.files_exists == 'true'
+      uses: shivammathur/setup-php@v2
       with:
-        php-version: ${{ matrix.php }}
+        php-version: '${{ matrix.php }}'
+        tools: composer
         extensions: 'xdebug'
-
     - uses: actions/checkout@v2
+
+    - name: Install Composer dependencies & cache dependencies
+      if: steps.check_files.outputs.files_exists == 'true'
+      uses: "ramsey/composer-install@v2"
+      with:
+        composer-options: "--prefer-dist"
+        custom-cache-key: "{{ runner.os }}-composer-${{ matrix.php }}"
+      env:
+        COMPOSER_ROOT_VERSION: dev-${{ github.event.repository.default_branch }}
 
     - name: Validate composer.json and composer.lock
       #run: composer validate --strict  # Currently we’re installing mf2/tests from a commit ref.
       run: composer validate
-
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v2
-      with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-
-
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress
 
     - name: Run Test Suite
       run: XDEBUG_MODE=coverage ./vendor/bin/phpunit tests --coverage-text


### PR DESCRIPTION
It seems composer has moved on at a pace that made the 5.6 branch die.

Rather than embrace that, I've fixed the issue, and perhaps simplified the GitHub action?

See https://github.com/Lewiscowles1986/php-mf2/pull/3 (checked this passes CI first)

This may be required for https://github.com/microformats/php-mf2/pull/235 to land.