### PR TITLE
Feature/php 8 and 8.1 CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     
     strategy:
       matrix:
-        php: ['5.6', '7.3', '7.4']
+        php: ['5.6', '7.3', '7.4', '8.0', '8.1']
 
     runs-on: ubuntu-latest
 

--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -364,10 +364,11 @@ class Parser {
 	 * @param boolean $jsonMode Whether or not to use a stdClass instance for an empty `rels` dictionary. This breaks PHP looping over rels, but allows the output to be correctly serialized as JSON.
 	 */
 	public function __construct($input, $url = null, $jsonMode = false) {
+		$emptyDocDefault = '<html><body></body></html>';
 		libxml_use_internal_errors(true);
 		if (is_string($input)) {
 			if (empty($input)) {
-					$input = '<html><body></body></html>';
+					$input = $emptyDocDefault;
 			}
 				
 			if (class_exists('Masterminds\\HTML5')) {
@@ -381,7 +382,7 @@ class Parser {
 			$doc = clone $input;
 		} else {
 			$doc = new DOMDocument();
-			@$doc->loadHTML('');
+			@$doc->loadHTML($emptyDocDefault);
 		}
 
 		// Create an XPath object and allow some PHP functions to be used within XPath queries.

--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -366,6 +366,10 @@ class Parser {
 	public function __construct($input, $url = null, $jsonMode = false) {
 		libxml_use_internal_errors(true);
 		if (is_string($input)) {
+			if (empty($input)) {
+					$input = '<html><body></body></html>';
+			}
+				
 			if (class_exists('Masterminds\\HTML5')) {
 					$doc = new \Masterminds\HTML5(array('disable_html_ns' => true));
 					$doc = $doc->loadHTML($input);


### PR DESCRIPTION
This builds on #236 and #235 

Originally I just wanted to revive #213 but it seems CI was borked for 5.6, and then I wanted more modern PHP8 support.

<details>
<summary>old notes</summary>

> ⚠️ **Warning**
> This commit history depends on another to pass CI a separate issue #236 has been raised to fix that.
> Also to keep PHPUnit compatible between PHP version, it's using work from #235 
> https://github.com/Lewiscowles1986/php-mf2/pull/5 shows the combination passing CI

</details>

🟢 All good now the dependent PR's have merged.