### PR TITLE
Allow Manual Trigger of Builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Could help maintainers avoid overhead of making a branch or re-running past action workflow runs.