### PR TITLE
Scheduled Builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: Build
 
 on:
+  schedule:
+  - cron: '0 0 1 * 0'
   push:
     branches: [ main ]
   pull_request:


### PR DESCRIPTION
This can help prevent discovery that CI isn't building after N months, and provide history of when it breaks.

1 month is fine for projects without too much changing. Feel free to ask for adjustment if you feel a week or daily, or some other cron-expressable schedule is more appropriate.