### PR TITLE
Add allow-plugins to composer.json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,6 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 charset = utf-8
 
-[*.yml]
+[*.{json,yml}]
 indent_style = space
 indent_size = 2

--- a/composer.json
+++ b/composer.json
@@ -1,51 +1,51 @@
 {
-	"name": "mf2/mf2",
-	"type": "library",
-	"description": "A pure, generic microformats2 parser — makes HTML as easy to consume as a JSON API",
-	"keywords": ["microformats", "microformats 2", "parser", "semantic", "html"],
-	"authors" : [
-		{
-			"name": "Barnaby Walters",
-			"homepage": "http://waterpigs.co.uk"
-		}
-	],
-	"bin": ["bin/fetch-mf2", "bin/parse-mf2"],
-	"require": {
-		"php": ">=5.6.0"
-	},
-	"config": {
-		"platform": {
-		},
-		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
-	},
-	"require-dev": {
-		"mf2/tests": "dev-master#e9e2b905821ba0a5b59dab1a8eaf40634ce9cd49",
-		"squizlabs/php_codesniffer": "^3.6.2",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-		  "phpcompatibility/php-compatibility": "^9.3",
-		"yoast/phpunit-polyfills": "^1.0"
-	},
-	"scripts": {
-		"cs-check": "phpcs",
-		"tests": "XDEBUG_MODE=coverage ./vendor/bin/phpunit tests --coverage-text --whitelist Mf2",
-		"test-mf1": "./vendor/bin/phpunit --group microformats/tests/mf1",
-		"check-and-test": [
-			"@cs-check",
-			"@tests"
-		],
-		"check-and-test-all": [
-			"@check-and-test",
-			"@test-mf1"
-		]
-	},
-	"autoload": {
-		"files": ["Mf2/Parser.php"]
-	},
-	"license": "CC0-1.0",
-	"suggest": {
-		"barnabywalters/mf-cleaner": "To more easily handle the canonical data php-mf2 gives you",
-		"masterminds/html5": "Alternative HTML parser for PHP, for better HTML5 support."
-	}
+    "name": "mf2/mf2",
+    "type": "library",
+    "description": "A pure, generic microformats2 parser — makes HTML as easy to consume as a JSON API",
+    "keywords": ["microformats", "microformats 2", "parser", "semantic", "html"],
+    "authors" : [
+        {
+            "name": "Barnaby Walters",
+            "homepage": "http://waterpigs.co.uk"
+        }
+    ],
+    "bin": ["bin/fetch-mf2", "bin/parse-mf2"],
+    "require": {
+        "php": ">=5.6.0"
+    },
+    "config": {
+        "platform": {
+        },
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
+    "require-dev": {
+        "mf2/tests": "dev-master#e9e2b905821ba0a5b59dab1a8eaf40634ce9cd49",
+        "squizlabs/php_codesniffer": "^3.6.2",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+        "phpcompatibility/php-compatibility": "^9.3",
+        "yoast/phpunit-polyfills": "^1.0"
+    },
+    "scripts": {
+        "cs-check": "phpcs",
+        "tests": "XDEBUG_MODE=coverage ./vendor/bin/phpunit tests --coverage-text --whitelist Mf2",
+        "test-mf1": "./vendor/bin/phpunit --group microformats/tests/mf1",
+        "check-and-test": [
+            "@cs-check",
+            "@tests"
+        ],
+        "check-and-test-all": [
+            "@check-and-test",
+            "@test-mf1"
+        ]
+    },
+    "autoload": {
+        "files": ["Mf2/Parser.php"]
+    },
+    "license": "CC0-1.0",
+    "suggest": {
+        "barnabywalters/mf-cleaner": "To more easily handle the canonical data php-mf2 gives you",
+        "masterminds/html5": "Alternative HTML parser for PHP, for better HTML5 support."
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,48 +1,51 @@
 {
-    "name": "mf2/mf2",
-    "type": "library",
-    "description": "A pure, generic microformats2 parser — makes HTML as easy to consume as a JSON API",
-    "keywords": ["microformats", "microformats 2", "parser", "semantic", "html"],
-    "authors" : [
-        {
-            "name": "Barnaby Walters",
-            "homepage": "http://waterpigs.co.uk"
-        }
-    ],
-    "bin": ["bin/fetch-mf2", "bin/parse-mf2"],
-    "require": {
-        "php": ">=5.6.0"
-    },
-    "config": {
-       "platform": {
-       }
-    },
-    "require-dev": {
-        "mf2/tests": "dev-master#e9e2b905821ba0a5b59dab1a8eaf40634ce9cd49",
-        "squizlabs/php_codesniffer": "^3.6.2",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-	      "phpcompatibility/php-compatibility": "^9.3",
-        "yoast/phpunit-polyfills": "^1.0"
-    },
-    "scripts": {
-        "cs-check": "phpcs",
-        "tests": "XDEBUG_MODE=coverage ./vendor/bin/phpunit tests --coverage-text --whitelist Mf2",
-        "test-mf1": "./vendor/bin/phpunit --group microformats/tests/mf1",
-        "check-and-test": [
-            "@cs-check",
-            "@tests"
-        ],
-        "check-and-test-all": [
-            "@check-and-test",
-            "@test-mf1"
-        ]
-    },
-    "autoload": {
-        "files": ["Mf2/Parser.php"]
-    },
-    "license": "CC0-1.0",
-    "suggest": {
-        "barnabywalters/mf-cleaner": "To more easily handle the canonical data php-mf2 gives you",
-        "masterminds/html5": "Alternative HTML parser for PHP, for better HTML5 support."
-    }
+	"name": "mf2/mf2",
+	"type": "library",
+	"description": "A pure, generic microformats2 parser — makes HTML as easy to consume as a JSON API",
+	"keywords": ["microformats", "microformats 2", "parser", "semantic", "html"],
+	"authors" : [
+		{
+			"name": "Barnaby Walters",
+			"homepage": "http://waterpigs.co.uk"
+		}
+	],
+	"bin": ["bin/fetch-mf2", "bin/parse-mf2"],
+	"require": {
+		"php": ">=5.6.0"
+	},
+	"config": {
+		"platform": {
+		},
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	},
+	"require-dev": {
+		"mf2/tests": "dev-master#e9e2b905821ba0a5b59dab1a8eaf40634ce9cd49",
+		"squizlabs/php_codesniffer": "^3.6.2",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+		  "phpcompatibility/php-compatibility": "^9.3",
+		"yoast/phpunit-polyfills": "^1.0"
+	},
+	"scripts": {
+		"cs-check": "phpcs",
+		"tests": "XDEBUG_MODE=coverage ./vendor/bin/phpunit tests --coverage-text --whitelist Mf2",
+		"test-mf1": "./vendor/bin/phpunit --group microformats/tests/mf1",
+		"check-and-test": [
+			"@cs-check",
+			"@tests"
+		],
+		"check-and-test-all": [
+			"@check-and-test",
+			"@test-mf1"
+		]
+	},
+	"autoload": {
+		"files": ["Mf2/Parser.php"]
+	},
+	"license": "CC0-1.0",
+	"suggest": {
+		"barnabywalters/mf-cleaner": "To more easily handle the canonical data php-mf2 gives you",
+		"masterminds/html5": "Alternative HTML parser for PHP, for better HTML5 support."
+	}
 }


### PR DESCRIPTION
Needed `allow-plugins` for build breaking during `composer install` ([example](https://github.com/microformats/php-mf2/actions/runs/3123441634/jobs/5066093904)).

I had included this in PR https://github.com/microformats/php-mf2/pull/241, but am removing it from there and making its own PR so I can try to get the builds passing again before merging #238 and #239.

Also updated .editorconfig to preserve the whitespace in composer.json.