### PR TITLE
Fix invalid property class name parsing

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -166,14 +166,10 @@ function nestedMfPropertyNamesFromClass($class) {
 	$prefixes = array('p-', 'u-', 'dt-', 'e-');
 	$propertyNames = array();
 
-	$class = str_replace(array(' ', '	', "\n"), ' ', $class);
-	foreach (explode(' ', $class) as $classname) {
-		foreach ($prefixes as $prefix) {
-			// Check if $classname is a valid property classname for $prefix.
-			if (mb_substr($classname, 0, mb_strlen($prefix)) == $prefix && $classname != $prefix) {
-				$propertyName = mb_substr($classname, mb_strlen($prefix));
-				$propertyNames[$propertyName][] = $prefix;
-			}
+	foreach ($prefixes as $prefix) {
+		$classes = mfNamesFromClass($class, $prefix);
+		foreach ($classes as $property) {
+			$propertyNames[$property][] = $prefix;
 		}
 	}
 

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -902,6 +902,57 @@ EOF;
 	/**
 	 * @see https://github.com/microformats/php-mf2/issues/249
 	 */
+	public function testInvalidRootsIgnored() {
+		$input = <<<EOF
+<div class=" h-5 pt-2">
+	<div class="p-4 h-entry">
+		<a class="u-url" href="https://example.com/bar">bar </a>
+	</div>
+	<div class="p-4 h-entry">
+		<a class="u-url" href="https://example.com/foo">foo</a>
+	</div>
+</div>
+EOF;
+		$output = Mf2\parse($input);
+
+		# `items` should have length=2
+		$this->assertEquals(2, count($output['items']));
+
+		# each should be an h-entry
+		$this->assertEquals('h-entry', $output['items'][0]['type'][0]);
+		$this->assertEquals('h-entry', $output['items'][1]['type'][0]);
+	}
+
+	/**
+	 * @see https://github.com/microformats/php-mf2/issues/249
+	 */
+	public function testInvalidNestedRootsIgnored() {
+		$input = <<<EOF
+<div class=" h-5 pt-2">
+	<div class="p-4 h-entry">
+		<a class="u-url" href="https://example.com/bar">bar </a>
+	</div>
+	<div class="p-4 h-entry">
+		<a class="u-url" href="https://example.com/foo">foo</a>
+	</div>
+	<div class="p-4 h-5">
+		<a class="u-url" href="https://example.com/baz">baz</a>
+	</div>
+</div>
+EOF;
+		$output = Mf2\parse($input);
+
+		# `items` should have length=2
+		$this->assertEquals(2, count($output['items']));
+
+		# each should be an h-entry
+		$this->assertEquals('h-entry', $output['items'][0]['type'][0]);
+		$this->assertEquals('h-entry', $output['items'][1]['type'][0]);
+	}
+
+	/**
+	 * @see https://github.com/microformats/php-mf2/issues/249
+	 */
 	public function testInvalidNestedPropertiesIgnored1() {
 		$input = <<<EOF
 <div class=" h-feed pt-2">


### PR DESCRIPTION
The `nestedMfPropertyNamesFromClass` method was parsing property classes regardless if they were valid (e.g. `p-4`). Updated the method to use existing `mfNamesFromClass` method, which uses the correct regex to skip those classes.

Also fixed a test for `nestedMfPropertyNamesFromClass` which asserted the response array was equal. The expected and actual response array had the same values, but in different order. The order is not important in that response, so I switched the assertion to `assertEqualsCanonicalizing`.

This also appeared to fix #246, so I added a test to confirm that.

Fixes #249
Fixes #246