### PR TITLE
Update tests

### DIFF
--- a/tests/Mf2/ClassicMicroformatsTest.php
+++ b/tests/Mf2/ClassicMicroformatsTest.php
@@ -15,7 +15,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  *
  * Contains tests of the classic microformat => µf2 functionality.
  *
- * Mainly based off BC tables on http://microformats.org/wiki/microformats2#v2_vocabularies
+ * Mainly based off BC tables on https://microformats.org/wiki/microformats2#v2_vocabularies
  */
 class ClassicMicroformatsTest extends TestCase {
 	protected function set_up() {
@@ -152,7 +152,7 @@ EOT;
 <div class="vevent">
 <h3 class="summary">XYZ Project Review</h3>
 <p class="description">Project XYZ Review Meeting</p>
-<p> <a class="url" href="http://example.com/xyz-meeting">http://example.com/xyz-meeting</a> </p>
+<p> <a class="url" href="https://example.com/xyz-meeting">https://example.com/xyz-meeting</a> </p>
 <p>To be held on
  <span class="dtstart">
   <abbr class="value" title="1998-03-12">the 12th of March</abbr>
@@ -181,7 +181,7 @@ EOT;
 
 		$this->assertEquals('XYZ Project Review', $output['items'][0]['properties']['name'][0]);
 		$this->assertEquals('Project XYZ Review Meeting', $output['items'][0]['properties']['description'][0]);
-		$this->assertEquals('http://example.com/xyz-meeting', $output['items'][0]['properties']['url'][0]);
+		$this->assertEquals('https://example.com/xyz-meeting', $output['items'][0]['properties']['url'][0]);
 		$this->assertEquals('1998-03-12 08:30-0500', $output['items'][0]['properties']['start'][0]);
 		$this->assertEquals('1998-03-12 09:30-0500', $output['items'][0]['properties']['end'][0]);
 	}
@@ -255,7 +255,7 @@ END;
 
 
 	/**
-	 * @see http://microformats.org/wiki/microformats2-parsing-issues#any_h-_root_class_name_overrides_and_stops_backcompat_root
+	 * @see https://microformats.org/wiki/microformats2-parsing-issues#any_h-_root_class_name_overrides_and_stops_backcompat_root
 	 */
 	public function testMf2RootStopsBackcompatRoot() {
 		$input = '<div class="adr h-adr">
@@ -273,7 +273,7 @@ END;
 
 
 	/**
-	 * @see http://microformats.org/wiki/microformats2-parsing-issues#any_h-_root_class_name_overrides_and_stops_backcompat_root
+	 * @see https://microformats.org/wiki/microformats2-parsing-issues#any_h-_root_class_name_overrides_and_stops_backcompat_root
 	 */
 	public function testMf2CustomRootStopsBackcompatRoot() {
 		$input = '<div class="adr h-acme-address">
@@ -291,7 +291,7 @@ END;
 
 
 	/**
-	 * @see http://microformats.org/wiki/microformats2-parsing-issues#uf2_children_on_backcompat_properties
+	 * @see https://microformats.org/wiki/microformats2-parsing-issues#uf2_children_on_backcompat_properties
 	 */
 	public function testMf2ChildrenOnBackcompatProperties() {
 		$input = '<div class="vcard">
@@ -753,7 +753,7 @@ END;
 
 
 	/**
-	 * @see http://microformats.org/wiki/hReview#Examples
+	 * @see https://microformats.org/wiki/hReview#Examples
 	 */
 	public function testParsesClassicHreview() {
 		$input = <<< END
@@ -767,7 +767,7 @@ END;
 	</div>
 	<p>Visit date: <span>April 2005</span></p>
 	<p>Food eaten: <span>Florentine crepe</span></p>
-	<p>Permanent link for review: <a rel="self bookmark" href="http://example.com/crepe">http://example.com/crepe</a></p>
+	<p>Permanent link for review: <a rel="self bookmark" href="https://example.com/crepe">https://example.com/crepe</a></p>
 </div>
 END;
 		$parser = new Parser($input);

--- a/tests/Mf2/CombinedMicroformatsTest.php
+++ b/tests/Mf2/CombinedMicroformatsTest.php
@@ -11,7 +11,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
  * Combined Microformats Test
  *
  * Tests the ability of Parser::parse() to handle nested microformats correctly.
- * More info at http://microformats.org/wiki/microformats-2#combining_microformats
+ * More info at https://microformats.org/wiki/microformats-2#combining_microformats
  *
  * @todo implement
  */
@@ -23,18 +23,20 @@ class CombinedMicroformatsTest extends TestCase {
 	}
 
 	/**
-	 * From http://microformats.org/wiki/microformats2#combining_microformats
+	 * From https://microformats.org/wiki/microformats2#combining_microformats
 	 */
 	public function testHEventLocationHCard() {
+		// Note: The venue for IWC 2012 no longer exists so we switched
+		// this to Powell's since it's a long-term Portland institution
 		$input = '<div class="h-event">
-	<a class="p-name u-url" href="http://indiewebcamp.com/2012">
+	<a class="p-name u-url" href="https://indieweb.org/2012">
 	IndieWebCamp 2012
 	</a>
 	from <time class="dt-start">2012-06-30</time>
 	to <time class="dt-end">2012-07-01</time> at
 	<span class="p-location h-card">
-	<a class="p-name p-org u-url" href="http://geoloqi.com/">
-	Geoloqi</a>, <span class="p-street-address">920 SW 3rd Ave. Suite 400</span>, <span class="p-locality">Portland</span>, <abbr class="p-region" title="Oregon">OR</abbr>
+	<a class="p-name p-org u-url" href="https://www.powells.com/">
+	Powell’s</a>, <span class="p-street-address">1005 W Burnside St.</span>, <span class="p-locality">Portland</span>, <abbr class="p-region" title="Oregon">OR</abbr>
   </span>
 </div>';
 		$expected = '{
@@ -44,17 +46,17 @@ class CombinedMicroformatsTest extends TestCase {
 		"type": ["h-event"],
 		"properties": {
 			"name": ["IndieWebCamp 2012"],
-			"url": ["http://indiewebcamp.com/2012"],
+			"url": ["https://indieweb.org/2012"],
 			"start": ["2012-06-30"],
 			"end": ["2012-07-01"],
 			"location": [{
-				"value": "Geoloqi",
+				"value": "Powell’s",
 				"type": ["h-card"],
 				"properties": {
-					"name": ["Geoloqi"],
-					"org": ["Geoloqi"],
-					"url": ["http://geoloqi.com/"],
-					"street-address": ["920 SW 3rd Ave. Suite 400"],
+					"name": ["Powell’s"],
+					"org": ["Powell’s"],
+					"url": ["https://www.powells.com/"],
+					"street-address": ["1005 W Burnside St."],
 					"locality": ["Portland"],
 					"region": ["Oregon"]
 				}
@@ -71,7 +73,7 @@ class CombinedMicroformatsTest extends TestCase {
 	}
 
 	/**
-	 * From http://microformats.org/wiki/microformats2#combining_microformats
+	 * From https://microformats.org/wiki/microformats2#combining_microformats
 	 */
 	public function testHCardOrgPOrg() {
 		$input = '<div class="h-card">
@@ -101,7 +103,7 @@ class CombinedMicroformatsTest extends TestCase {
 	}
 
 	/**
-	 * From http://microformats.org/wiki/microformats2#combining_microformats
+	 * From https://microformats.org/wiki/microformats2#combining_microformats
 	 */
 	public function testHCardOrgHCard() {
 		$input = '<div class="h-card">
@@ -140,7 +142,7 @@ class CombinedMicroformatsTest extends TestCase {
 	}
 
 	/**
-	 * From http://microformats.org/wiki/microformats2#combining_microformats
+	 * From https://microformats.org/wiki/microformats2#combining_microformats
 	 */
 	public function testHCardPOrgHCardHOrg() {
 		$input = '<div class="h-card">
@@ -178,7 +180,7 @@ class CombinedMicroformatsTest extends TestCase {
 	}
 
 	/**
-	 * From http://microformats.org/wiki/microformats2#combining_microformats
+	 * From https://microformats.org/wiki/microformats2#combining_microformats
 	 */
 	public function testHCardChildHCard() {
 		$input = '<div class="h-card">
@@ -257,9 +259,9 @@ class CombinedMicroformatsTest extends TestCase {
 		  <p class="e-content">Hello World</p>
 		  <ul>
 		    <li class="u-comment h-cite">
-		    	<a class="u-author h-card" href="http://jane.example.com/">Jane Bloggs</a>
+		    	<a class="u-author h-card" href="https://jane.example.com/">Jane Bloggs</a>
 		    	<p class="p-content p-name">lol</p>
-		    	<a class="u-url" href="http://example.org/post1234"><time class="dt-published">2015-07-12 12:03</time></a>
+		    	<a class="u-url" href="https://example.com/post1234"><time class="dt-published">2015-07-12 12:03</time></a>
 		    </li>
 		  </ul>
 		</div>';
@@ -279,16 +281,16 @@ class CombinedMicroformatsTest extends TestCase {
                 "type": ["h-card"],
                 "properties": {
                   "name": ["Jane Bloggs"],
-                  "url": ["http:\/\/jane.example.com\/"]
+                  "url": ["https:\/\/jane.example.com\/"]
                 },
-                "value": "http:\/\/jane.example.com\/"
+                "value": "https:\/\/jane.example.com\/"
               }],
               "content": ["lol"],
               "name": ["lol"],
-              "url": ["http:\/\/example.org\/post1234"],
+              "url": ["https:\/\/example.com\/post1234"],
               "published": ["2015-07-12 12:03"]
             },
-            "value": "http:\/\/example.org\/post1234"
+            "value": "https:\/\/example.com\/post1234"
           }]
 	      }
 	    }],
@@ -298,8 +300,8 @@ class CombinedMicroformatsTest extends TestCase {
 	  	$mf = Mf2\parse($input);
 
 		$this->assertJsonStringEqualsJsonString(json_encode($mf), $expected);
-		$this->assertEquals($mf['items'][0]['properties']['comment'][0]['value'], 'http://example.org/post1234');
-		$this->assertEquals($mf['items'][0]['properties']['comment'][0]['properties']['author'][0]['value'], 'http://jane.example.com/');
+		$this->assertEquals($mf['items'][0]['properties']['comment'][0]['value'], 'https://example.com/post1234');
+		$this->assertEquals($mf['items'][0]['properties']['comment'][0]['properties']['author'][0]['value'], 'https://jane.example.com/');
 	}
 
 	public function testMicroformatsNestedUnderPPropertyClassnamesDeriveValueFromFirstPName() {

--- a/tests/Mf2/MicroformatsWikiExamplesTest.php
+++ b/tests/Mf2/MicroformatsWikiExamplesTest.php
@@ -54,7 +54,7 @@ class MicroformatsWikiExamplesTest extends TestCase {
 	}
 
 	/**
-	 * From http://microformats.org/wiki/microformats-2
+	 * From https://microformats.org/wiki/microformats-2
 	 */
 	public function testSimplePersonReference() {
 		$input = '<span class="h-card">Frances Berriman</span>';
@@ -75,7 +75,7 @@ class MicroformatsWikiExamplesTest extends TestCase {
 	}
 
 	/**
-	 * From http://microformats.org/wiki/microformats-2
+	 * From https://microformats.org/wiki/microformats-2
 	 */
 	public function testSimpleHyperlinkedPersonReference() {
 		$input = '<a class="h-card" href="http://benward.me">Ben Ward</a>';
@@ -97,10 +97,10 @@ class MicroformatsWikiExamplesTest extends TestCase {
 	}
 
 	/**
-	 * From http://microformats.org/wiki/microformats-2-implied-properties
+	 * From https://microformats.org/wiki/microformats-2-implied-properties
 	 */
 	public function testSimplePersonImage() {
-		$input = '<img class="h-card" src="http://example.org/pic.jpg" alt="Chris Messina" />';
+		$input = '<img class="h-card" src="http://example.com/pic.jpg" alt="Chris Messina" />';
 		// Added root items key
 		$expected = '{
 	"rels": {},
@@ -110,7 +110,7 @@ class MicroformatsWikiExamplesTest extends TestCase {
   "properties": {
 	"name": ["Chris Messina"],
 	"photo": [{
-		"value": "http://example.org/pic.jpg",
+		"value": "http://example.com/pic.jpg",
 		"alt": "Chris Messina"
 	}]
   }
@@ -122,7 +122,7 @@ class MicroformatsWikiExamplesTest extends TestCase {
 	}
 
 	/**
-	 * From http://microformats.org/wiki/microformats-2-implied-properties
+	 * From https://microformats.org/wiki/microformats-2-implied-properties
 	 */
 	public function testHyperlinkedImageNameAndPhotoProperties() {
 		$input = '<a class="h-card" href="http://rohit.khare.org/">
@@ -151,7 +151,7 @@ class MicroformatsWikiExamplesTest extends TestCase {
 	}
 
 	/**
-	 * From http://microformats.org/wiki/microformats-2
+	 * From https://microformats.org/wiki/microformats-2
 	 */
 	public function testMoreDetailedPerson() {
 		$input = '<div class="h-card">

--- a/tests/Mf2/ParseDTTest.php
+++ b/tests/Mf2/ParseDTTest.php
@@ -297,7 +297,7 @@ class ParseDTTest extends TestCase {
 	/**
 	 * TZ offsets normalized only for VCP.
 	 * This behavior is implied from "However the colons ":" separating the hours and minutes of any timezone offset are optional and discouraged in order to make it less likely that a timezone offset will be confused for a time."
-	 * @see http://microformats.org/wiki/index.php?title=value-class-pattern&oldid=66473##However+the+colons
+	 * @see https://microformats.org/wiki/index.php?title=value-class-pattern&oldid=66473##However+the+colons
 	 */
 	public function testNormalizeTZOffsetVCP() {
 		$input = '<div class="h-event">

--- a/tests/Mf2/ParseImpliedTest.php
+++ b/tests/Mf2/ParseImpliedTest.php
@@ -54,56 +54,56 @@ class ParseImpliedTest extends TestCase {
 	}
 
 	public function testParsesImpliedUPhotoFromImgSrcWithoutAlt() {
-		$input = '<img class="h-card" src="http://example.com/img.png" />';
+		$input = '<img class="h-card" src="https://example.com/img.png" />';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('photo', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/img.png', $output['items'][0]['properties']['photo'][0]);
+		$this->assertEquals('https://example.com/img.png', $output['items'][0]['properties']['photo'][0]);
 	}
 
 	public function testParsesImpliedUPhotoFromImgSrcWithEmptyAlt() {
-		$input = '<img class="h-card" src="http://example.com/img.png" alt="" />';
+		$input = '<img class="h-card" src="https://example.com/img.png" alt="" />';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('photo', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/img.png', $output['items'][0]['properties']['photo'][0]['value']);
+		$this->assertEquals('https://example.com/img.png', $output['items'][0]['properties']['photo'][0]['value']);
 		$this->assertEquals('', $output['items'][0]['properties']['photo'][0]['alt']);
 	}
 
 	public function testParsesImpliedUPhotoFromImgSrcWithAlt() {
-		$input = '<img class="h-card" src="http://example.com/img.png" alt="Example" />';
+		$input = '<img class="h-card" src="https://example.com/img.png" alt="Example" />';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('photo', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/img.png', $output['items'][0]['properties']['photo'][0]['value']);
+		$this->assertEquals('https://example.com/img.png', $output['items'][0]['properties']['photo'][0]['value']);
 		$this->assertEquals('Example', $output['items'][0]['properties']['photo'][0]['alt']);
 	}
 
 	public function testParsesImpliedUPhotoFromNestedImgSrc() {
-		$input = '<div class="h-card"><img src="http://example.com/img.png" alt="" /></div>';
+		$input = '<div class="h-card"><img src="https://example.com/img.png" alt="" /></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('photo', $output['items'][0]['properties']);
 		$return = [
-			'value' => 'http://example.com/img.png',
+			'value' => 'https://example.com/img.png',
 			'alt'=> ''
 			];
 		$this->assertEquals( $return, $output['items'][0]['properties']['photo'][0]);
 	}
 
 	public function testParsesImpliedUPhotoFromDoublyNestedImgSrc() {
-		$input = '<div class="h-card"><span><img src="http://example.com/img.png" alt="" /></span></div>';
+		$input = '<div class="h-card"><span><img src="https://example.com/img.png" alt="" /></span></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('photo', $output['items'][0]['properties']);
 		$result = [
 			'alt' => '',
-			'value' => 'http://example.com/img.png'
+			'value' => 'https://example.com/img.png'
 			];
 		$this->assertEquals($result, $output['items'][0]['properties']['photo'][0]);
 	}
@@ -111,7 +111,7 @@ class ParseImpliedTest extends TestCase {
 	/*
 	 * see testImpliedPhotoFromNestedObject() and testImpliedPhotoFromNestedObject()
 	public function testIgnoresImgIfNotOnlyChild() {
-		$input = '<div class="h-card"><img src="http://example.com/img.png" /> <p>Moar text</p></div>';
+		$input = '<div class="h-card"><img src="https://example.com/img.png" /> <p>Moar text</p></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
@@ -119,7 +119,7 @@ class ParseImpliedTest extends TestCase {
 	}
 
 	public function testIgnoresDoublyNestedImgIfNotOnlyDoublyNestedChild() {
-		$input = '<div class="h-card"><span><img src="http://example.com/img.png" /> <p>Moar text</p></span></div>';
+		$input = '<div class="h-card"><span><img src="https://example.com/img.png" /> <p>Moar text</p></span></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
@@ -128,40 +128,40 @@ class ParseImpliedTest extends TestCase {
 	*/
 
 	public function testParsesImpliedUUrlFromAHref() {
-		$input = '<a class="h-card" href="http://example.com/">Some Name</a>';
+		$input = '<a class="h-card" href="https://example.com/">Some Name</a>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('url', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/', $output['items'][0]['properties']['url'][0]);
+		$this->assertEquals('https://example.com/', $output['items'][0]['properties']['url'][0]);
 	}
 
 
 	public function testParsesImpliedUUrlFromNestedAHref() {
-		$input = '<span class="h-card"><a href="http://example.com/">Some Name</a></span>';
+		$input = '<span class="h-card"><a href="https://example.com/">Some Name</a></span>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('url', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/', $output['items'][0]['properties']['url'][0]);
+		$this->assertEquals('https://example.com/', $output['items'][0]['properties']['url'][0]);
 	}
 
   public function testParsesImpliedUUrlWithExplicitName() {
-    $input = '<span class="h-card"><a href="http://example.com/" class="p-name">Some Name</a></span>';
+    $input = '<span class="h-card"><a href="https://example.com/" class="p-name">Some Name</a></span>';
     $parser = new Parser($input);
     $output = $parser->parse();
 
     $this->assertArrayHasKey('url', $output['items'][0]['properties']);
-    $this->assertEquals('http://example.com/', $output['items'][0]['properties']['url'][0]);
+    $this->assertEquals('https://example.com/', $output['items'][0]['properties']['url'][0]);
   }
 
   public function testParsesImpliedNameWithExplicitURL() {
-    $input = '<span class="h-card"><a href="http://example.com/" class="u-url">Some Name</a></span>';
+    $input = '<span class="h-card"><a href="https://example.com/" class="u-url">Some Name</a></span>';
     $parser = new Parser($input);
     $output = $parser->parse();
 
     $this->assertArrayHasKey('url', $output['items'][0]['properties']);
-    $this->assertEquals('http://example.com/', $output['items'][0]['properties']['url'][0]);
+    $this->assertEquals('https://example.com/', $output['items'][0]['properties']['url'][0]);
     $this->assertEquals('Some Name', $output['items'][0]['properties']['name'][0]);
   }
 
@@ -249,7 +249,7 @@ class ParseImpliedTest extends TestCase {
 	/**
 	 * Correcting previous test testIgnoresImgIfNotOnlyChild()
 	 * This *should* return the photo since h-x>img[src]:only-of-type:not[.h-*]
-	 * @see https://indiewebcamp.com/User:Tantek.com
+	 * @see https://indieweb.org/User:Tantek.com
 	 */
 	public function testImpliedPhotoFromNestedImg() {
 		$input = '<span class="h-card"><a href="http://tantek.com/" class="external text" style="border: 0px none;"><img src="https://pbs.twimg.com/profile_images/423350922408767488/nlA_m2WH.jpeg" style="width:128px;float:right;margin-left:1em"><b><span style="font-size:2em">Tantek Çelik</span></b></a></span>';
@@ -348,7 +348,7 @@ class ParseImpliedTest extends TestCase {
 
 	/**
 	 * Imply properties only on explicit h-x class name root microformat element (no backcompat roots)
-	 * @see http://microformats.org/wiki/microformats2-parsing#parsing_for_implied_properties
+	 * @see https://microformats.org/wiki/microformats2-parsing#parsing_for_implied_properties
 	 */
 	public function testBackcompatNoImpliedName() {
 		$input = '<div class="hentry"> <div class="entry-content"> <p> blah blah blah </p> </div> </div>';
@@ -361,7 +361,7 @@ class ParseImpliedTest extends TestCase {
 
 	/**
 	 * Imply properties only on explicit h-x class name root microformat element (no backcompat roots)
-	 * @see http://microformats.org/wiki/microformats2-parsing#parsing_for_implied_properties
+	 * @see https://microformats.org/wiki/microformats2-parsing#parsing_for_implied_properties
 	 */
 	public function testBackcompatNoImpliedPhoto() {
 		$input = '<div class="hentry"> <img src="https://example.com/photo.jpg" alt="photo" /> </div>';
@@ -373,7 +373,7 @@ class ParseImpliedTest extends TestCase {
 
 	/**
 	 * Imply properties only on explicit h-x class name root microformat element (no backcompat roots)
-	 * @see http://microformats.org/wiki/microformats2-parsing#parsing_for_implied_properties
+	 * @see https://microformats.org/wiki/microformats2-parsing#parsing_for_implied_properties
 	 */
 	public function testBackcompatNoImpliedUrl() {
 		$input = '<div class="hentry"> <a href="https://example.com/this-post" class="entry-title">Title</a> <div class="entry-content"> <p> blah blah blah </p> </div> </div>';
@@ -387,11 +387,11 @@ class ParseImpliedTest extends TestCase {
 
 	/**
 	 * Don't imply u-url if there are other u-*
-	 * @see http://microformats.org/wiki/microformats2-parsing#parsing_for_implied_properties
+	 * @see https://microformats.org/wiki/microformats2-parsing#parsing_for_implied_properties
 	 * @see https://github.com/microformats/php-mf2/issues/183
 	 */
 	public function testNoImpliedUrl() {
-		$input = '<div class="h-entry"> <h1 class="p-name"><a href="https://example.com/this-post">Title</a></h1> <div class="e-content"> <p> blah blah blah </p> </div> <a href="https://example.org/syndicate" class="u-syndication"></a> </div>';
+		$input = '<div class="h-entry"> <h1 class="p-name"><a href="https://example.com/this-post">Title</a></h1> <div class="e-content"> <p> blah blah blah </p> </div> <a href="https://othersite.example.com/syndicate" class="u-syndication"></a> </div>';
 		$result = Mf2\parse($input);
 
 		$this->assertArrayNotHasKey('url', $result['items'][0]['properties']);

--- a/tests/Mf2/ParsePTest.php
+++ b/tests/Mf2/ParsePTest.php
@@ -92,14 +92,14 @@ class ParsePTest extends TestCase {
 	}
 
 	public function testParsesInputValue() {
-		$input = '<span class="h-card"><input class="u-url" value="http://example.com" /></span>';
+		$input = '<span class="h-card"><input class="u-url" value="https://example.com" /></span>';
 		$result = Mf2\parse($input);
-		$this->assertEquals('http://example.com', $result['items'][0]['properties']['url'][0]);
+		$this->assertEquals('https://example.com', $result['items'][0]['properties']['url'][0]);
 	}
 
 	/**
 	 * @see https://github.com/indieweb/php-mf2/issues/53
-	 * @see http://microformats.org/wiki/microformats2-parsing#parsing_an_e-_property
+	 * @see https://microformats.org/wiki/microformats2-parsing#parsing_an_e-_property
 	 */
 	public function testConvertsNestedImgElementToAltOrSrc() {
 		$input = <<<EOT

--- a/tests/Mf2/ParseUTest.php
+++ b/tests/Mf2/ParseUTest.php
@@ -18,12 +18,12 @@ class ParseUTest extends TestCase {
 	 * @group parseU
 	 */
 	public function testParseUHandlesA() {
-		$input = '<div class="h-card"><a class="u-url" href="http://example.com">Awesome example website</a></div>';
+		$input = '<div class="h-card"><a class="u-url" href="https://example.com">Awesome example website</a></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('url', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com', $output['items'][0]['properties']['url'][0]);
+		$this->assertEquals('https://example.com', $output['items'][0]['properties']['url'][0]);
 	}
 
 	/**
@@ -31,11 +31,11 @@ class ParseUTest extends TestCase {
 	 */
 	public function testParseUHandlesEmptyHrefAttribute() {
 		$input = '<div class="h-card"><a class="u-url" href="">Awesome example website</a></div>';
-		$parser = new Parser($input, "http://example.com/");
+		$parser = new Parser($input, "https://example.com/");
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('url', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/', $output['items'][0]['properties']['url'][0]);
+		$this->assertEquals('https://example.com/', $output['items'][0]['properties']['url'][0]);
 	}
 
 	/**
@@ -43,36 +43,36 @@ class ParseUTest extends TestCase {
 	 */
 	public function testParseUHandlesMissingHrefAttribute() {
 		$input = '<div class="h-card"><a class="u-url">Awesome example website</a></div>';
-		$parser = new Parser($input, "http://example.com/");
+		$parser = new Parser($input, "https://example.com/");
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('url', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/Awesome example website', $output['items'][0]['properties']['url'][0]);
+		$this->assertEquals('https://example.com/Awesome example website', $output['items'][0]['properties']['url'][0]);
 	}
 
 	/**
 	 * @group parseU
 	 */
 	public function testParseUHandlesImg() {
-		$input = '<div class="h-card"><img class="u-photo" src="http://example.com/someimage.png"></div>';
+		$input = '<div class="h-card"><img class="u-photo" src="https://example.com/someimage.png"></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('photo', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/someimage.png', $output['items'][0]['properties']['photo'][0]);
+		$this->assertEquals('https://example.com/someimage.png', $output['items'][0]['properties']['photo'][0]);
 	}
 
 	/**
 	 * @group parseU
 	 */
 	public function testParseUHandlesImgwithAlt() {
-		$input = '<div class="h-card"><img class="u-photo" src="http://example.com/someimage.png" alt="Test Alt"></div>';
+		$input = '<div class="h-card"><img class="u-photo" src="https://example.com/someimage.png" alt="Test Alt"></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('photo', $output['items'][0]['properties']);
 		$result = array(
-			'value' => 'http://example.com/someimage.png',
+			'value' => 'https://example.com/someimage.png',
 			'alt' => 'Test Alt'
 		);
 		$this->assertEquals( $result, $output['items'][0]['properties']['photo'][0]);
@@ -82,48 +82,48 @@ class ParseUTest extends TestCase {
 	 * @group parseU
 	 */
 	public function testParseUHandlesImgwithoutAlt() {
-		$input = '<div class="h-card"><img class="u-photo" src="http://example.com/someimage.png"></div>';
+		$input = '<div class="h-card"><img class="u-photo" src="https://example.com/someimage.png"></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('photo', $output['items'][0]['properties']);
-		$this->assertEquals( 'http://example.com/someimage.png', $output['items'][0]['properties']['photo'][0]);
+		$this->assertEquals( 'https://example.com/someimage.png', $output['items'][0]['properties']['photo'][0]);
 	}
 
 	/**
 	 * @group parseU
 	 */
 	public function testParseUHandlesArea() {
-		$input = '<div class="h-card"><area class="u-photo" href="http://example.com/someimage.png"></area></div>';
+		$input = '<div class="h-card"><area class="u-photo" href="https://example.com/someimage.png"></area></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('photo', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/someimage.png', $output['items'][0]['properties']['photo'][0]);
+		$this->assertEquals('https://example.com/someimage.png', $output['items'][0]['properties']['photo'][0]);
 	}
 
 	/**
 	 * @group parseU
 	 */
 	public function testParseUHandlesObject() {
-		$input = '<div class="h-card"><object class="u-photo" data="http://example.com/someimage.png"></object></div>';
+		$input = '<div class="h-card"><object class="u-photo" data="https://example.com/someimage.png"></object></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('photo', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/someimage.png', $output['items'][0]['properties']['photo'][0]);
+		$this->assertEquals('https://example.com/someimage.png', $output['items'][0]['properties']['photo'][0]);
 	}
 
 	/**
 	 * @group parseU
 	 */
 	public function testParseUHandlesAbbr() {
-		$input = '<div class="h-card"><abbr class="u-photo" title="http://example.com/someimage.png"></abbr></div>';
+		$input = '<div class="h-card"><abbr class="u-photo" title="https://example.com/someimage.png"></abbr></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('photo', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/someimage.png', $output['items'][0]['properties']['photo'][0]);
+		$this->assertEquals('https://example.com/someimage.png', $output['items'][0]['properties']['photo'][0]);
 	}
 
 	/**
@@ -142,12 +142,12 @@ class ParseUTest extends TestCase {
 	 * @group parseU
 	 */
 	public function testParseUHandlesData() {
-		$input = '<div class="h-card"><data class="u-photo" value="http://example.com/someimage.png"></data></div>';
+		$input = '<div class="h-card"><data class="u-photo" value="https://example.com/someimage.png"></data></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('photo', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/someimage.png', $output['items'][0]['properties']['photo'][0]);
+		$this->assertEquals('https://example.com/someimage.png', $output['items'][0]['properties']['photo'][0]);
 	}
 
 	/**
@@ -155,21 +155,21 @@ class ParseUTest extends TestCase {
 	 */
 	public function testResolvesRelativeUrlsFromDocumentUrl() {
 		$input = '<div class="h-card"><img class="u-photo" src="../image.png" /></div>';
-		$parser = new Parser($input, 'http://example.com/things/more/more.html');
+		$parser = new Parser($input, 'https://example.com/things/more/more.html');
 		$output = $parser->parse();
 
-		$this->assertEquals('http://example.com/things/image.png', $output['items'][0]['properties']['photo'][0]);
+		$this->assertEquals('https://example.com/things/image.png', $output['items'][0]['properties']['photo'][0]);
 	}
 
 	/**
 	 * @group baseUrl
 	 */
 	public function testResolvesRelativeUrlsFromBaseUrl() {
-		$input = '<head><base href="http://example.com/things/more/andmore/" /></head><body><div class="h-card"><img class="u-photo" src="../image.png" /></div></body>';
-		$parser = new Parser($input, 'http://example.com/things/more.html');
+		$input = '<head><base href="https://example.com/things/more/andmore/" /></head><body><div class="h-card"><img class="u-photo" src="../image.png" /></div></body>';
+		$parser = new Parser($input, 'https://example.com/things/more.html');
 		$output = $parser->parse();
 
-		$this->assertEquals('http://example.com/things/more/image.png', $output['items'][0]['properties']['photo'][0]);
+		$this->assertEquals('https://example.com/things/more/image.png', $output['items'][0]['properties']['photo'][0]);
 	}
 
 	/**
@@ -177,10 +177,10 @@ class ParseUTest extends TestCase {
 	 */
 	public function testResolvesRelativeUrlsInImpliedMicroformats() {
 		$input = '<a class="h-card"><img src="image.png" /></a>';
-		$parser = new Parser($input, 'http://example.com/things/more.html');
+		$parser = new Parser($input, 'https://example.com/things/more.html');
 		$output = $parser->parse();
 
-		$this->assertEquals('http://example.com/things/image.png', $output['items'][0]['properties']['photo'][0]);
+		$this->assertEquals('https://example.com/things/image.png', $output['items'][0]['properties']['photo'][0]);
 	}
 
 	/**
@@ -188,41 +188,41 @@ class ParseUTest extends TestCase {
 	 */
 	public function testResolvesRelativeBaseRelativeUrlsInImpliedMicroformats() {
 		$input = '<base href="things/"/><a class="h-card"><img src="image.png" /></a>';
-		$parser = new Parser($input, 'http://example.com/');
+		$parser = new Parser($input, 'https://example.com/');
 		$output = $parser->parse();
 
-		$this->assertEquals('http://example.com/things/image.png', $output['items'][0]['properties']['photo'][0]);
+		$this->assertEquals('https://example.com/things/image.png', $output['items'][0]['properties']['photo'][0]);
 	}
 
 	/** @see https://github.com/indieweb/php-mf2/issues/33 */
 	public function testParsesHrefBeforeValueClass() {
-		$input = '<span class="h-card"><a class="u-url" href="http://example.com/right"><span class="value">WRONG</span></a></span>';
+		$input = '<span class="h-card"><a class="u-url" href="https://example.com/right"><span class="value">WRONG</span></a></span>';
 		$result = Mf2\parse($input);
-		$this->assertEquals('http://example.com/right', $result['items'][0]['properties']['url'][0]);
+		$this->assertEquals('https://example.com/right', $result['items'][0]['properties']['url'][0]);
 	}
 
 	/**
 	 * @group parseU
 	 */
 	public function testParseUHandlesAudio() {
-		$input = '<div class="h-entry"><audio class="u-audio" src="http://example.com/audio.mp3"></div>';
+		$input = '<div class="h-entry"><audio class="u-audio" src="https://example.com/audio.mp3"></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('audio', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/audio.mp3', $output['items'][0]['properties']['audio'][0]);
+		$this->assertEquals('https://example.com/audio.mp3', $output['items'][0]['properties']['audio'][0]);
 	}
 
 	/**
 	 * @group parseU
 	 */
 	public function testParseUHandlesVideo() {
-		$input = '<div class="h-entry"><video class="u-video" src="http://example.com/video.mp4"></video></div>';
+		$input = '<div class="h-entry"><video class="u-video" src="https://example.com/video.mp4"></video></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('video', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/video.mp4', $output['items'][0]['properties']['video'][0]);
+		$this->assertEquals('https://example.com/video.mp4', $output['items'][0]['properties']['video'][0]);
 	}
 
 	/**
@@ -241,38 +241,38 @@ class ParseUTest extends TestCase {
 	 * @group parseU
 	 */
 	public function testParseUHandlesSource() {
-		$input = '<div class="h-entry"><video><source class="u-video" src="http://example.com/video.mp4" type="video/mp4"><source class="u-video" src="http://example.com/video.ogg" type="video/ogg"></video></div>';
+		$input = '<div class="h-entry"><video><source class="u-video" src="https://example.com/video.mp4" type="video/mp4"><source class="u-video" src="https://example.com/video.ogg" type="video/ogg"></video></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('video', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/video.mp4', $output['items'][0]['properties']['video'][0]);
-		$this->assertEquals('http://example.com/video.ogg', $output['items'][0]['properties']['video'][1]);
+		$this->assertEquals('https://example.com/video.mp4', $output['items'][0]['properties']['video'][0]);
+		$this->assertEquals('https://example.com/video.ogg', $output['items'][0]['properties']['video'][1]);
 	}
 
 	/**
 	 * @group parseU
 	 */
 	public function testParseUHandlesVideoPoster() {
-		$input = '<div class="h-entry"><video class="u-photo" poster="http://example.com/posterimage.jpg"><source class="u-video" src="http://example.com/video.mp4" type="video/mp4"></video></div>';
+		$input = '<div class="h-entry"><video class="u-photo" poster="https://example.com/posterimage.jpg"><source class="u-video" src="https://example.com/video.mp4" type="video/mp4"></video></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('video', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/video.mp4', $output['items'][0]['properties']['video'][0]);
-		$this->assertEquals('http://example.com/posterimage.jpg', $output['items'][0]['properties']['photo'][0]);
+		$this->assertEquals('https://example.com/video.mp4', $output['items'][0]['properties']['video'][0]);
+		$this->assertEquals('https://example.com/posterimage.jpg', $output['items'][0]['properties']['photo'][0]);
 	}
 
 	/**
 	 * @group parseU
 	 */
 	public function testParseUWithSpaces() {
-		$input = '<div class="h-card"><a class="u-url" href=" http://example.com ">Awesome example website</a></div>';
+		$input = '<div class="h-card"><a class="u-url" href=" https://example.com ">Awesome example website</a></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('url', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com', $output['items'][0]['properties']['url'][0]);
+		$this->assertEquals('https://example.com', $output['items'][0]['properties']['url'][0]);
 	}
 
 	/**
@@ -284,23 +284,23 @@ class ParseUTest extends TestCase {
 <div class="h-card" ><a href="">Jane Doe</a><p></p></div>
 <div class="h-card" ><area href="">Jane Doe</area><p></p></div>
 <div class="h-card" ><a class="h-card" href="">Jane Doe</a><p></p></div>';
-		$parser = new Parser($input, 'http://example.com');
+		$parser = new Parser($input, 'https://example.com');
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('url', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/', $output['items'][0]['properties']['url'][0]);
+		$this->assertEquals('https://example.com/', $output['items'][0]['properties']['url'][0]);
 
 		$this->assertArrayHasKey('url', $output['items'][1]['properties']);
-		$this->assertEquals('http://example.com/', $output['items'][1]['properties']['url'][0]);
+		$this->assertEquals('https://example.com/', $output['items'][1]['properties']['url'][0]);
 
 		$this->assertArrayHasKey('url', $output['items'][2]['properties']);
-		$this->assertEquals('http://example.com/', $output['items'][2]['properties']['url'][0]);
+		$this->assertEquals('https://example.com/', $output['items'][2]['properties']['url'][0]);
 
 		$this->assertArrayHasKey('url', $output['items'][3]['properties']);
-		$this->assertEquals('http://example.com/', $output['items'][3]['properties']['url'][0]);
+		$this->assertEquals('https://example.com/', $output['items'][3]['properties']['url'][0]);
 
 		$this->assertArrayHasKey('url', $output['items'][4]['children'][0]['properties']);
-		$this->assertEquals('http://example.com/', $output['items'][4]['children'][0]['properties']['url'][0]);
+		$this->assertEquals('https://example.com/', $output['items'][4]['children'][0]['properties']['url'][0]);
 	}
 
 	public function testValueFromLinkTag() {

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -104,11 +104,11 @@ class ParserTest extends TestCase {
 
 	public function testParseEResolvesRelativeLinks() {
 		$input = '<div class="h-entry"><p class="e-content">Blah blah <a href="/a-url">thing</a>. <object data="/object"></object> <img src="/img" /></p></div>';
-		$parser = new Parser($input, 'http://example.com');
+		$parser = new Parser($input, 'https://example.com');
 		$output = $parser->parse();
 
-		$this->assertEquals('Blah blah <a href="http://example.com/a-url">thing</a>. <object data="http://example.com/object"></object> <img src="http://example.com/img">', $output['items'][0]['properties']['content'][0]['html']);
-		$this->assertEquals('Blah blah thing. http://example.com/img', $output['items'][0]['properties']['content'][0]['value']);
+		$this->assertEquals('Blah blah <a href="https://example.com/a-url">thing</a>. <object data="https://example.com/object"></object> <img src="https://example.com/img">', $output['items'][0]['properties']['content'][0]['html']);
+		$this->assertEquals('Blah blah thing. https://example.com/img', $output['items'][0]['properties']['content'][0]['value']);
 	}
 
 	public function testParseEWithBR() {
@@ -191,23 +191,23 @@ class ParserTest extends TestCase {
 	}
 
 	public function testParsesRelValues() {
-		$input = '<a rel="author" href="http://example.com">Mr. Author</a>';
+		$input = '<a rel="author" href="https://example.com">Mr. Author</a>';
 		$parser = new Parser($input);
 
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('rels', $output);
-		$this->assertEquals('http://example.com', $output['rels']['author'][0]);
+		$this->assertEquals('https://example.com', $output['rels']['author'][0]);
 	}
 
 	public function testParsesRelAlternateValues() {
-		$input = '<a rel="alternate home" href="http://example.org" hreflang="de", media="screen" type="text/html" title="German Homepage Link">German Homepage</a>';
+		$input = '<a rel="alternate home" href="https://example.com" hreflang="de", media="screen" type="text/html" title="German Homepage Link">German Homepage</a>';
 		$parser = new Parser($input);
 		$parser->enableAlternates = true;
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('alternates', $output);
-		$this->assertEquals('http://example.org', $output['alternates'][0]['url']);
+		$this->assertEquals('https://example.com', $output['alternates'][0]['url']);
 		$this->assertEquals('home', $output['alternates'][0]['rel']);
 		$this->assertEquals('de', $output['alternates'][0]['hreflang']);
 		$this->assertEquals('screen', $output['alternates'][0]['media']);
@@ -300,7 +300,7 @@ EOT;
 
 	/**
 	 * @see https://github.com/indieweb/php-mf2/issues/53
-	 * @see http://microformats.org/wiki/microformats2-parsing#parsing_an_e-_property
+	 * @see https://microformats.org/wiki/microformats2-parsing#parsing_an_e-_property
 	 */
 	public function testConvertsNestedImgElementToAltOrSrc() {
 		$input = <<<EOT
@@ -616,7 +616,7 @@ EOT;
 	{
 		$input = '<article class="h-entry">
 	<div class="u-like-of h-cite">
-		<p>I really like <a class="p-name u-url" href="http://microformats.org/">Microformats</a></p>
+		<p>I really like <a class="p-name u-url" href="https://microformats.org/">Microformats</a></p>
 	</div>
 	<footer>
 		<p>Footer to be ignored.</p>
@@ -755,7 +755,7 @@ END;
 	 */
 	public function testConsecutiveDashes() {
 		$input = '<div class="h-entry h-----">
-<p> <a href="http://example.com/post" class="u-in-reply--to">http://example.com/post posted:</a> </p>
+<p> <a href="https://example.com/post" class="u-in-reply--to">https://example.com/post posted:</a> </p>
 <span class="p-name">Too many dashes</span>
 <span class="p--acme-leading">leading dash</span>
 <span class="p-acme--middle">middle dash</span>

--- a/tests/Mf2/RelTest.php
+++ b/tests/Mf2/RelTest.php
@@ -11,79 +11,79 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class RelTest extends TestCase {
   public function testRelValueOnLinkTag() {
-    $input = '<link rel="webmention" href="http://example.com/webmention">';
+    $input = '<link rel="webmention" href="https://example.com/webmention">';
     $parser = new Parser($input);
     $output = $parser->parse();
 
     $this->assertArrayHasKey('webmention', $output['rels']);
-    $this->assertEquals('http://example.com/webmention', $output['rels']['webmention'][0]);
+    $this->assertEquals('https://example.com/webmention', $output['rels']['webmention'][0]);
   }
 
   public function testRelValueOnATag() {
-    $input = '<a rel="webmention" href="http://example.com/webmention">webmention me</a>';
+    $input = '<a rel="webmention" href="https://example.com/webmention">webmention me</a>';
     $parser = new Parser($input);
     $output = $parser->parse();
 
     $this->assertArrayHasKey('webmention', $output['rels']);
-    $this->assertEquals('http://example.com/webmention', $output['rels']['webmention'][0]);
+    $this->assertEquals('https://example.com/webmention', $output['rels']['webmention'][0]);
   }
 
   public function testRelValueOnAreaTag() {
-    $input = '<map><area rel="webmention" href="http://example.com/webmention"/></map>';
+    $input = '<map><area rel="webmention" href="https://example.com/webmention"/></map>';
     $parser = new Parser($input);
     $output = $parser->parse();
 
     $this->assertArrayHasKey('webmention', $output['rels']);
-    $this->assertEquals('http://example.com/webmention', $output['rels']['webmention'][0]);
+    $this->assertEquals('https://example.com/webmention', $output['rels']['webmention'][0]);
   }
 
   public function testRelValueOrder() {
-    $input = '<map><area rel="webmention" href="http://example.com/area"/></map>
-      <a rel="webmention" href="http://example.com/a">webmention me</a>
-      <link rel="webmention" href="http://example.com/link">';
+    $input = '<map><area rel="webmention" href="https://example.com/area"/></map>
+      <a rel="webmention" href="https://example.com/a">webmention me</a>
+      <link rel="webmention" href="https://example.com/link">';
     $parser = new Parser($input);
     $output = $parser->parse();
 
     $this->assertArrayHasKey('webmention', $output['rels']);
-    $this->assertEquals('http://example.com/area', $output['rels']['webmention'][0]);
-    $this->assertEquals('http://example.com/a', $output['rels']['webmention'][1]);
-    $this->assertEquals('http://example.com/link', $output['rels']['webmention'][2]);
+    $this->assertEquals('https://example.com/area', $output['rels']['webmention'][0]);
+    $this->assertEquals('https://example.com/a', $output['rels']['webmention'][1]);
+    $this->assertEquals('https://example.com/link', $output['rels']['webmention'][2]);
   }
 
   public function testRelValueOrder2() {
-    $input = '<map><area rel="webmention" href="http://example.com/area"/></map>
-      <link rel="webmention" href="http://example.com/link">
-      <a rel="webmention" href="http://example.com/a">webmention me</a>';
+    $input = '<map><area rel="webmention" href="https://example.com/area"/></map>
+      <link rel="webmention" href="https://example.com/link">
+      <a rel="webmention" href="https://example.com/a">webmention me</a>';
     $parser = new Parser($input);
     $output = $parser->parse();
 
     $this->assertArrayHasKey('webmention', $output['rels']);
-    $this->assertEquals('http://example.com/area', $output['rels']['webmention'][0]);
-    $this->assertEquals('http://example.com/link', $output['rels']['webmention'][1]);
-    $this->assertEquals('http://example.com/a', $output['rels']['webmention'][2]);
+    $this->assertEquals('https://example.com/area', $output['rels']['webmention'][0]);
+    $this->assertEquals('https://example.com/link', $output['rels']['webmention'][1]);
+    $this->assertEquals('https://example.com/a', $output['rels']['webmention'][2]);
   }
 
   public function testRelValueOrder3() {
     $input = '<html>
       <head>
-        <link rel="webmention" href="http://example.com/link">
+        <link rel="webmention" href="https://example.com/link">
       </head>
       <body>
-        <a rel="webmention" href="http://example.com/a">webmention me</a>
-        <map><area rel="webmention" href="http://example.com/area"/></map>
+        <a rel="webmention" href="https://example.com/a">webmention me</a>
+        <map><area rel="webmention" href="https://example.com/area"/></map>
       </body>
     </html>';
     $parser = new Parser($input);
     $output = $parser->parse();
 
     $this->assertArrayHasKey('webmention', $output['rels']);
-    $this->assertEquals('http://example.com/link', $output['rels']['webmention'][0]);
-    $this->assertEquals('http://example.com/a', $output['rels']['webmention'][1]);
-    $this->assertEquals('http://example.com/area', $output['rels']['webmention'][2]);
+    $this->assertEquals('https://example.com/link', $output['rels']['webmention'][0]);
+    $this->assertEquals('https://example.com/a', $output['rels']['webmention'][1]);
+    $this->assertEquals('https://example.com/area', $output['rels']['webmention'][2]);
   }
 
   public function testRelValueOnBTag() {
-    $input = '<b rel="webmention" href="http://example.com/webmention">this makes no sense</b>';
+    $input = '<b rel="webmention" href="https://example.com/webmention">this makes no sense</b>';
     $parser = new Parser($input);
     $output = $parser->parse();
 
@@ -91,12 +91,12 @@ class RelTest extends TestCase {
   }
 
   public function testEnableAlternatesFlagTrue() {
-    $input = '<a rel="author" href="http://example.com/a">author a</a>
-<a rel="author" href="http://example.com/b">author b</a>
-<a rel="in-reply-to" href="http://example.com/1">post 1</a>
-<a rel="in-reply-to" href="http://example.com/2">post 2</a>
+    $input = '<a rel="author" href="https://example.com/a">author a</a>
+<a rel="author" href="https://example.com/b">author b</a>
+<a rel="in-reply-to" href="https://example.com/1">post 1</a>
+<a rel="in-reply-to" href="https://example.com/2">post 2</a>
 <a rel="alternate home"
-   href="http://example.com/fr"
+   href="https://example.com/fr"
    media="handheld"
    hreflang="fr">French mobile homepage</a>';
     $parser = new Parser($input);
@@ -107,12 +107,12 @@ class RelTest extends TestCase {
   }
 
   public function testEnableAlternatesFlagFalse() {
-    $input = '<a rel="author" href="http://example.com/a">author a</a>
-<a rel="author" href="http://example.com/b">author b</a>
-<a rel="in-reply-to" href="http://example.com/1">post 1</a>
-<a rel="in-reply-to" href="http://example.com/2">post 2</a>
+    $input = '<a rel="author" href="https://example.com/a">author a</a>
+<a rel="author" href="https://example.com/b">author b</a>
+<a rel="in-reply-to" href="https://example.com/1">post 1</a>
+<a rel="in-reply-to" href="https://example.com/2">post 2</a>
 <a rel="alternate home"
-   href="http://example.com/fr"
+   href="https://example.com/fr"
    media="handheld"
    hreflang="fr">French mobile homepage</a>';
     $parser = new Parser($input);
@@ -124,18 +124,18 @@ class RelTest extends TestCase {
 
   /**
    * @see https://github.com/indieweb/php-mf2/issues/112
-   * @see http://microformats.org/wiki/microformats2-parsing#rel_parse_examples
+   * @see https://microformats.org/wiki/microformats2-parsing#rel_parse_examples
    */
   public function testRelURLs() {
-    $input = '<a rel="author" href="http://example.com/a">author a</a>
-<a rel="author" href="http://example.com/b">author b</a>
-<a rel="in-reply-to" href="http://example.com/1">post 1</a>
-<a rel="in-reply-to" href="http://example.com/2">post 2</a>
+    $input = '<a rel="author" href="https://example.com/a">author a</a>
+<a rel="author" href="https://example.com/b">author b</a>
+<a rel="in-reply-to" href="https://example.com/1">post 1</a>
+<a rel="in-reply-to" href="https://example.com/2">post 2</a>
 <a rel="alternate home"
-   href="http://example.com/fr"
+   href="https://example.com/fr"
    media="handheld"
    hreflang="fr">French mobile homepage</a>
-<link rel="alternate" type="application/atom+xml" href="http://example.com/articles.atom" title="Atom Feed" />';
+<link rel="alternate" type="application/atom+xml" href="https://example.com/articles.atom" title="Atom Feed" />';
     $parser = new Parser($input);
     $output = $parser->parse();
 
@@ -148,28 +148,28 @@ class RelTest extends TestCase {
 
     $this->assertArrayHasKey('rel-urls', $output);
     $this->assertCount(6, $output['rel-urls']);
-    $this->assertArrayHasKey('http://example.com/a', $output['rel-urls']);
-    $this->assertArrayHasKey('http://example.com/b', $output['rel-urls']);
-    $this->assertArrayHasKey('http://example.com/1', $output['rel-urls']);
-    $this->assertArrayHasKey('http://example.com/2', $output['rel-urls']);
-    $this->assertArrayHasKey('http://example.com/fr', $output['rel-urls']);
-    $this->assertArrayHasKey('http://example.com/articles.atom', $output['rel-urls']);
+    $this->assertArrayHasKey('https://example.com/a', $output['rel-urls']);
+    $this->assertArrayHasKey('https://example.com/b', $output['rel-urls']);
+    $this->assertArrayHasKey('https://example.com/1', $output['rel-urls']);
+    $this->assertArrayHasKey('https://example.com/2', $output['rel-urls']);
+    $this->assertArrayHasKey('https://example.com/fr', $output['rel-urls']);
+    $this->assertArrayHasKey('https://example.com/articles.atom', $output['rel-urls']);
 
-    $this->assertArrayHasKey('rels', $output['rel-urls']['http://example.com/a']);
-    $this->assertArrayHasKey('text', $output['rel-urls']['http://example.com/a']);
-    $this->assertArrayHasKey('rels', $output['rel-urls']['http://example.com/b']);
-    $this->assertArrayHasKey('text', $output['rel-urls']['http://example.com/b']);
-    $this->assertArrayHasKey('rels', $output['rel-urls']['http://example.com/1']);
-    $this->assertArrayHasKey('text', $output['rel-urls']['http://example.com/1']);
-    $this->assertArrayHasKey('rels', $output['rel-urls']['http://example.com/2']);
-    $this->assertArrayHasKey('text', $output['rel-urls']['http://example.com/2']);
-    $this->assertArrayHasKey('rels', $output['rel-urls']['http://example.com/fr']);
-    $this->assertArrayHasKey('text', $output['rel-urls']['http://example.com/fr']);
-    $this->assertArrayHasKey('media', $output['rel-urls']['http://example.com/fr']);
-    $this->assertArrayHasKey('hreflang', $output['rel-urls']['http://example.com/fr']);
-    $this->assertArrayHasKey('title', $output['rel-urls']['http://example.com/articles.atom']);
-    $this->assertArrayHasKey('type', $output['rel-urls']['http://example.com/articles.atom']);
-    $this->assertArrayHasKey('rels', $output['rel-urls']['http://example.com/articles.atom']);
+    $this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/a']);
+    $this->assertArrayHasKey('text', $output['rel-urls']['https://example.com/a']);
+    $this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/b']);
+    $this->assertArrayHasKey('text', $output['rel-urls']['https://example.com/b']);
+    $this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/1']);
+    $this->assertArrayHasKey('text', $output['rel-urls']['https://example.com/1']);
+    $this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/2']);
+    $this->assertArrayHasKey('text', $output['rel-urls']['https://example.com/2']);
+    $this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/fr']);
+    $this->assertArrayHasKey('text', $output['rel-urls']['https://example.com/fr']);
+    $this->assertArrayHasKey('media', $output['rel-urls']['https://example.com/fr']);
+    $this->assertArrayHasKey('hreflang', $output['rel-urls']['https://example.com/fr']);
+    $this->assertArrayHasKey('title', $output['rel-urls']['https://example.com/articles.atom']);
+    $this->assertArrayHasKey('type', $output['rel-urls']['https://example.com/articles.atom']);
+    $this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/articles.atom']);
   }
 
   /**

--- a/tests/Mf2/URLTest.php
+++ b/tests/Mf2/URLTest.php
@@ -113,14 +113,14 @@ class URLTest extends TestCase {
 	}
 
 	public function testNoPathOnBase() {
-		$actual = mf2\resolveUrl('http://example.com', '');
-		$this->assertEquals('http://example.com/', $actual);
+		$actual = mf2\resolveUrl('https://example.com', '');
+		$this->assertEquals('https://example.com/', $actual);
 
-		$actual = mf2\resolveUrl('http://example.com', '#');
-		$this->assertEquals('http://example.com/#', $actual);
+		$actual = mf2\resolveUrl('https://example.com', '#');
+		$this->assertEquals('https://example.com/#', $actual);
 
-		$actual = mf2\resolveUrl('http://example.com', '#thing');
-		$this->assertEquals('http://example.com/#thing', $actual);
+		$actual = mf2\resolveUrl('https://example.com', '#thing');
+		$this->assertEquals('https://example.com/#thing', $actual);
 	}
 
 	public function testMisc() {
@@ -139,12 +139,12 @@ class URLTest extends TestCase {
 
 	/** as per https://github.com/indieweb/php-mf2/issues/35 */
 	public function testResolvesProtocolRelativeUrlsCorrectly() {
-		$expected = 'http://cdn.example.org/thing/asset.css';
-		$actual = Mf2\resolveUrl('http://example.com', '//cdn.example.org/thing/asset.css');
+		$expected = 'https://cdn.example.com/thing/asset.css';
+		$actual = Mf2\resolveUrl('https://example.com', '//cdn.example.com/thing/asset.css');
 		$this->assertEquals($expected, $actual);
 
-		$expected = 'https://cdn.example.org/thing/asset.css';
-		$actual = Mf2\resolveUrl('https://example.com', '//cdn.example.org/thing/asset.css');
+		$expected = 'https://cdn.example.com/thing/asset.css';
+		$actual = Mf2\resolveUrl('https://example.com', '//cdn.example.com/thing/asset.css');
 		$this->assertEquals($expected, $actual);
 	}
 
@@ -162,49 +162,49 @@ class URLTest extends TestCase {
 		// fail message, base, url, expected
 		$cases = array(
 			array('Should return absolute URL unchanged',
-				'http://example.com', 'http://example.com', 'http://example.com'),
+				'https://example.com', 'https://example.com', 'https://example.com'),
 
 			array('Should return root given blank path',
-				'http://example.com', '', 'http://example.com/'),
+				'https://example.com', '', 'https://example.com/'),
 
 			array('Should return input unchanged given full URL and blank path',
-				'http://example.com/something', '', 'http://example.com/something'),
+				'https://example.com/something', '', 'https://example.com/something'),
 
 			array('Should handle blank base URL',
-				'', 'http://example.com', 'http://example.com'),
+				'', 'https://example.com', 'https://example.com'),
 
 			array('Should resolve fragment ID',
-				'http://example.com', '#thing', 'http://example.com/#thing'),
+				'https://example.com', '#thing', 'https://example.com/#thing'),
 
 			array('Should resolve blank fragment ID',
-				'http://example.com', '#', 'http://example.com/#'),
+				'https://example.com', '#', 'https://example.com/#'),
 
 			array('Should resolve same level URL',
-				'http://example.com', 'thing', 'http://example.com/thing'),
+				'https://example.com', 'thing', 'https://example.com/thing'),
 
 			array('Should resolve directory level URL',
-				'http://example.com', './thing', 'http://example.com/thing'),
+				'https://example.com', './thing', 'https://example.com/thing'),
 
 			array('Should resolve parent level URL at root level',
-				'http://example.com', '../thing', 'http://example.com/thing'),
+				'https://example.com', '../thing', 'https://example.com/thing'),
 
 			array('Should resolve nested URL',
-				'http://example.com/something', 'another', 'http://example.com/another'),
+				'https://example.com/something', 'another', 'https://example.com/another'),
 
 			array('Should ignore query strings in base url',
-				'http://example.com/index.php?url=http://example.org', '/thing', 'http://example.com/thing'),
+				'https://example.com/index.php?url=https://example.org', '/thing', 'https://example.com/thing'),
 
 			array('Should resolve query strings',
-				'http://example.com/thing', '?stuff=yes', 'http://example.com/thing?stuff=yes'),
+				'https://example.com/thing', '?stuff=yes', 'https://example.com/thing?stuff=yes'),
 
 			array('Should resolve dir level query strings',
-				'http://example.com', './?thing=yes', 'http://example.com/?thing=yes'),
+				'https://example.com', './?thing=yes', 'https://example.com/?thing=yes'),
 
 			array('Should resolve up one level from root domain',
-				'http://example.com', 'path/to/the/../file', 'http://example.com/path/to/file'),
+				'https://example.com', 'path/to/the/../file', 'https://example.com/path/to/file'),
 
 			array('Should resolve up one level from base with path',
-				'http://example.com/path/the', 'to/the/../file', 'http://example.com/path/to/file'),
+				'https://example.com/path/the', 'to/the/../file', 'https://example.com/path/to/file'),
 
 			// Tests from webignition library
 
@@ -218,7 +218,7 @@ class URLTest extends TestCase {
 				'http://user:pass@www.example.com', 'server.php', 'http://user:pass@www.example.com/server.php'),
 
 			array('relative base has file path',
-				'http://example.com/index.html', 'example.html', 'http://example.com/example.html'),
+				'https://example.com/index.html', 'example.html', 'https://example.com/example.html'),
 
 			array('input has absolute path',
 				'http://www.example.com/pathOne/pathTwo/pathThree', '/server.php?param1=value1', 'http://www.example.com/server.php?param1=value1'),
@@ -248,7 +248,7 @@ class URLTest extends TestCase {
 				'http://www.example.com/pathOne', './jquery.js', 'http://www.example.com/jquery.js'),
 
 			array('testAbsolutePathIncludesPortNumber',
-				'http://example.com:8080/index.html', '/photo.jpg', 'http://example.com:8080/photo.jpg')
+				'https://example.com:8080/index.html', '/photo.jpg', 'https://example.com:8080/photo.jpg')
 
 		);
 


### PR DESCRIPTION
- Use Powell's for Portland since Geoloqi no longer exists. 
- Standardized some example.org links to example.com. 
- Use https:// for example.com and microformats.org URLs. 
- Updated indiewebcamp.com to indieweb.org.

Some exceptions to the above are tests where the HTML was _not_ contrived but came from a published website.