### PR TITLE
Fix failing test

### DIFF
--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -382,11 +382,21 @@ EOT;
 	/**
 	 * @see https://github.com/indieweb/php-mf2/issues/84
 	 * @group internet
+	 *
+	 * 2024-04-07: The final photo URL in this test changed over time.
+	 * Updated it to only check that the final URL's hostname was correct,
+	 * not the full photo URL.
 	 */
 	public function testRelativeURLResolvedWithFinalURL() {
 		$mf = Mf2\fetch('http://aaron.pk/4Zn5');
 
-		$this->assertEquals('https://aaronparecki.com/img/1240x0/2014/12/23/5/photo.jpeg', $mf['items'][0]['properties']['photo'][0]);
+		$this->assertArrayHasKey('photo', $mf['items'][0]['properties']);
+
+		$hostname = parse_url($mf['items'][0]['properties']['photo'][0], PHP_URL_HOST);
+		$this->assertEquals('aaronparecki.com', $hostname);
+
+		// previous assertion: not the photo URL changed over time
+		// $this->assertEquals('https://aaronparecki.com/img/1240x0/2014/12/23/5/photo.jpeg', $mf['items'][0]['properties']['photo'][0]);
 	}
 
 	public function testScriptTagContentsRemovedFromTextValue() {


### PR DESCRIPTION
The original test from #84 (and https://github.com/microformats/mf2py/issues/62) was following a redirect from a short domain ensuring that the final domain was used to resolve relative URLs, by comparing the final URL of a photo in the post. The URL of the photo in that post changed, so this test started failing.

Updated the test to only check that the domain in the final photo URL is the one we expect.

Edit: this should fix the failing automated tests that I saw here: https://github.com/microformats/php-mf2/actions