### PR TITLE
GH Actions: only run PHPCS once + update CS dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,38 @@ on:
   workflow_dispatch:
 
 jobs:
+  phpcs:
+    name: 'PHPCS'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up PHP environment
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 'latest'
+        coverage: none
+        tools: cs2pr
+
+    - name: Install Composer dependencies & cache dependencies
+      uses: "ramsey/composer-install@v3"
+      with:
+        composer-options: "--prefer-dist"
+      env:
+        COMPOSER_ROOT_VERSION: dev-${{ github.event.repository.default_branch }}
+
+    - name: Run Code Sniffer
+      id: phpcs
+      run: ./vendor/bin/phpcs -ps --report-full --report-checkstyle=./phpcs-report.xml
+
+    - name: Show PHPCS results in PR
+      if: ${{ always() && steps.phpcs.outcome == 'failure' }}
+      run: cs2pr ./phpcs-report.xml
+
   build:
-    
+
     strategy:
       matrix:
         php: ['5.6', '7.3', '7.4', '8.0', '8.1']
@@ -41,9 +71,6 @@ jobs:
 
     - name: Run Test Suite
       run: XDEBUG_MODE=coverage ./vendor/bin/phpunit tests --coverage-text
-    
-    - name: Run Code Sniffer
-      run: ./vendor/bin/phpcs
-    
+
     #- name: Run Static Analysis
     #  run: ./vendor/bin/psalm

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     },
     "require-dev": {
         "mf2/tests": "dev-master#e9e2b905821ba0a5b59dab1a8eaf40634ce9cd49",
-        "squizlabs/php_codesniffer": "^3.6.2",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+        "squizlabs/php_codesniffer": "^3.10.2",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "phpcompatibility/php-compatibility": "^9.3",
         "yoast/phpunit-polyfills": "^1.0"
     },


### PR DESCRIPTION
### Composer: update some CS dependencies

The DealerDirect PHPCS Composer plugin has released version 1.0 quite a while ago. And if updating that, might as well update PHPCS as well.

### GH Actions: only run PHPCS once

All sniffs from PHPCS are set up to give the same results independently of the PHP version on which PHPCS is run, so there is no need to run it against multiple PHP versions in the matrix.

With this in mind, I'm suggesting to split off the PHPCS check into its own job.

Within that job, I've also set things up in a way that any CS errors will be shown inline in the code view if the build was run for a PR.