### PR TITLE
GH Actions: update action runner versions and run CI on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,10 @@ jobs:
         php-version: '${{ matrix.php }}'
         tools: composer
         extensions: 'xdebug'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install Composer dependencies & cache dependencies
-      uses: "ramsey/composer-install@v2"
+      uses: "ramsey/composer-install@v3"
       with:
         composer-options: "--prefer-dist"
         custom-cache-key: "{{ runner.os }}-composer-${{ matrix.php }}"


### PR DESCRIPTION
### GH Actions: update action runner versions

GitHub has deprecated the Node 16 action runner environment and will soon stop supporting it. Both the `actions/checkout` as well as `ramsey/composer-install` have released new versions for this.

Updating to those newer versions will prevent the CI from breaking once support for Node 16 is stopped completely.

### GH Actions: run CI on pull requests

... as otherwise new issues can be introduced without noticing.