### PR TITLE
PHPUnit: ignore the PHPUnit cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 /tmp
 .idea/
 /bin/test
+/.phpunit.result.cache


### PR DESCRIPTION
PHPUnit 8/9 introduced a cache file. This file should not be committed. To this end, I've added it to the `.gitignore` file.