### PR TITLE
PHP 8.2: fix dynamic property

### DIFF
--- a/tests/Mf2/CombinedMicroformatsTest.php
+++ b/tests/Mf2/CombinedMicroformatsTest.php
@@ -66,7 +66,6 @@ class CombinedMicroformatsTest extends TestCase {
 }';
 
 		$parser = new Parser($input, '', true);
-		$parser->stringDateTimes = true;
 		$output = $parser->parse();
 
 		$this->assertJsonStringEqualsJsonString(json_encode($output), $expected);
@@ -96,7 +95,6 @@ class CombinedMicroformatsTest extends TestCase {
 }';
 
 		$parser = new Parser($input, '', true);
-		$parser->stringDateTimes = true;
 		$output = $parser->parse();
 
 		$this->assertJsonStringEqualsJsonString(json_encode($output), $expected);
@@ -135,7 +133,6 @@ class CombinedMicroformatsTest extends TestCase {
 }';
 
 		$parser = new Parser($input, '', true);
-		$parser->stringDateTimes = true;
 		$output = $parser->parse();
 
 		$this->assertJsonStringEqualsJsonString(json_encode($output), $expected);


### PR DESCRIPTION
Looks like the `Parser::$stringDateTimes` property was removed in commit 7895e562a371ead5b1cb6eacb16a17dc23818633, which was part of the `0.2.0` release, so setting this non-declared property from the tests has no function.

Removing the property setting fixes the PHP 8.2 "Creation of dynamic property Mf2\Parser::$stringDateTimes is deprecated" deprecation notices.